### PR TITLE
build: add py.typed for PEP 561

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - HTTP server registers default request-id middleware and supports TLS via `certFile`/`keyFile`/`caFile`.
 
 ### Added
+- `py.typed` PEP 561 marker and `Typing :: Typed` classifier (typed package for consumers after next PyPI release).
 - `Event.marshal()` JSON envelope.
 - Scheduler `CallableExecutor`, sequential `Workflow.run` with retries/optional tasks, and `Worker` channel consumer.
 - Structured `/metrics` payload (uptime + optional SSE stats).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
+    "Typing :: Typed",
 ]
 dependencies = [
     "arrow==1.4.0",
@@ -37,6 +38,9 @@ Issues = "https://github.com/jovijovi/pypepper/issues"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["pypepper"]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary

- Problem: Downstream mypy/Pyright treat installed `pypepper` as untyped because no PEP 561 marker ships in the wheel.
- Why it matters: Editors and CI type-checkers for consumers get weak or missing diagnostics on library APIs.
- What changed: Empty `pypepper/py.typed`, hatchling `packages = ["pypepper"]` so the marker is included in the wheel, `Typing :: Typed` classifier, CHANGELOG Unreleased note.
- What did NOT change: No version bump, no PyPI publish; consumers see this after the next release.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] common
- [ ] event
- [ ] fsm
- [ ] helper
- [ ] network
- [ ] scheduler
- [x] CI/CD / infra

## Linked Issue/PR

- Related: P1 typed-package follow-up after docs/lint work

## User-visible / Behavior Changes

None at runtime. Packaging metadata only; typed-package signal for installers after next PyPI release.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local `.venv` + `python -m build` (hatchling)

### Steps

1. `python -m build`
2. `unzip -l dist/pypepper-*-py3-none-any.whl | grep py.typed`
3. Confirm METADATA contains `Typing :: Typed`

### Expected

- Wheel contains `pypepper/py.typed`; classifier present.

### Actual

- Confirmed: `pypepper/py.typed` in wheel; classifier OK.

## Evidence

- [x] Local wheel listing: `pypepper/py.typed` present (0-byte marker)
- [x] METADATA contains `Typing :: Typed`

## Human Verification (required)

- Verified scenarios: built sdist/wheel; inspected wheel members and METADATA
- Edge cases checked: hatchling includes marker with explicit `packages = ["pypepper"]` (no top-level `__init__.py`)
- What you did **not** verify: PyPI upload / downstream mypy against a published wheel

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR / remove `py.typed` and hatch wheel pin
- Files/config to restore: `pypepper/py.typed`, `pyproject.toml`, `CHANGELOG.md`
- Known bad symptoms reviewers should watch for: wheel missing `py.typed` on build

## Risks and Mitigations

- Risk: hatchling omits `py.typed` on this layout
  - Mitigation: explicit `[tool.hatch.build.targets.wheel] packages = ["pypepper"]`; verified in local wheel

## Test plan

- [x] `python -m build` includes `pypepper/py.typed` in the wheel
- [x] METADATA lists `Typing :: Typed`
- [ ] CI green on this PR