### PR TITLE
feat(common/tracing): add opt-in OpenTelemetry tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - HTTP server registers default request-id middleware and supports TLS via `certFile`/`keyFile`/`caFile`.
 
 ### Added
+- OpenTelemetry tracing (opt-in via `tracing` YAML): console exporter and OTLP HTTP to local Jaeger; HTTP + `Workflow.run` spans.
 - `py.typed` PEP 561 marker and `Typing :: Typed` classifier (typed package for consumers after next PyPI release).
 - `Event.marshal()` JSON envelope.
 - Scheduler `CallableExecutor`, sequential `Workflow.run` with retries/optional tasks, and `Worker` channel consumer.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,6 @@ Module loader.
 ## :bulb: Roadmap
 
 - [x] Documents
-- [ ] Tracing
+- [x] Tracing
 - [x] Harden shared mutable state / FSM rollback / SSE auth defaults
 - [x] ruff + mypy CI gate

--- a/conf/app.config.yaml
+++ b/conf/app.config.yaml
@@ -64,6 +64,15 @@ sse:
     enabled: true
     maxRequestsPerMinute: 60
 
+# OpenTelemetry tracing (default off). See docs/guides/tracing.md
+tracing:
+  enabled: false
+  serviceName: pypepper
+  console: false
+  otlp:
+    enabled: false
+    endpoint: http://127.0.0.1:4318
+
 # Custom config (Optional)
 custom:
   foo: "Something interesting"

--- a/devenv/dev.yaml
+++ b/devenv/dev.yaml
@@ -61,3 +61,15 @@ services:
       - "5432:5432"
     networks:
       - devenv-network-pypepper
+
+  # Local tracing UI only (not used in CI). OTLP HTTP :4318, UI :16686
+  jaeger:
+    container_name: devenv_jaeger_pypepper
+    image: jaegertracing/all-in-one:1.76.0
+    restart: unless-stopped
+    ports:
+      - "16686:16686"
+      - "4317:4317"
+      - "4318:4318"
+    networks:
+      - devenv-network-pypepper

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,5 +80,10 @@ sequenceDiagram
 
 ## Config surface
 
-Runtime YAML lives in `conf/app.config.yaml` (cluster, network, log, SSE, `custom`).
+Runtime YAML lives in `conf/app.config.yaml` (cluster, network, log, SSE, tracing, `custom`).
 Some config models (for example heartbeat / JSON-RPC proxy) are reserved and not yet wired to servers.
+
+## Observability
+
+Optional OpenTelemetry tracing is configured under `tracing` (default off). See [Tracing](guides/tracing.md).
+HTTP requests and `Workflow.run` emit spans when enabled; Jaeger all-in-one is available via `devenv/dev.yaml` for local UI only.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -77,3 +77,4 @@ Push to `main` deploys the site via GitHub Pages (`.github/workflows/docs.yml`).
 
 - Read [Architecture](architecture.md) for module boundaries
 - Follow a domain guide under **Guides**
+- Optional: enable [Tracing](guides/tracing.md) (console and/or local Jaeger)

--- a/docs/guides/tracing.md
+++ b/docs/guides/tracing.md
@@ -1,0 +1,84 @@
+# Tracing
+
+PyPepper ships optional [OpenTelemetry](https://opentelemetry.io/) tracing. It is **off by default**.
+
+When enabled, the library creates:
+
+- One **SERVER** span per HTTP request (`TracingMiddleware`), including `request_id` when set by `RequestIdMiddleware`
+- One span around `Workflow.run` (`scheduler.workflow.run`)
+
+`Context.trace(index)` in `pypepper.common.context` is unrelated — it walks the local context chain.
+
+## Configuration
+
+Add a `tracing` section to YAML (see `conf/app.config.yaml`):
+
+```yaml
+tracing:
+  enabled: false
+  serviceName: pypepper   # falls back to serviceInfo.serviceName
+  console: false          # print spans to the terminal
+  otlp:
+    enabled: false
+    endpoint: http://127.0.0.1:4318   # Jaeger / OTLP HTTP base URL
+```
+
+| Setting | Effect |
+|---------|--------|
+| `enabled: false` | No-op provider; no exporters |
+| `enabled: true` + `console: true` | `ConsoleSpanExporter` → terminal |
+| `enabled: true` + `otlp.enabled: true` | OTLP HTTP → `{endpoint}/v1/traces` |
+| Both console and otlp | Spans go to terminal **and** collector |
+
+`config.load_config()` calls `setup_from_config()` automatically.
+
+## Console (logs)
+
+```yaml
+tracing:
+  enabled: true
+  serviceName: pypepper
+  console: true
+  otlp:
+    enabled: false
+    endpoint: http://127.0.0.1:4318
+```
+
+Run an example and hit an endpoint; span JSON appears on stdout.
+
+## Jaeger UI (local / devenv only)
+
+Jaeger is provided for **development and manual verification**, not CI or production.
+
+Start the pinned all-in-one image:
+
+```shell
+docker compose -f devenv/dev.yaml up -d jaeger
+# or:
+docker run --rm --name jaeger \
+  -p 16686:16686 -p 4317:4317 -p 4318:4318 \
+  jaegertracing/all-in-one:1.76.0
+```
+
+Enable OTLP (and optionally console):
+
+```yaml
+tracing:
+  enabled: true
+  serviceName: pypepper
+  console: true
+  otlp:
+    enabled: true
+    endpoint: http://127.0.0.1:4318
+```
+
+```shell
+python example/server/app.py
+curl -s http://127.0.0.1:55550/health
+```
+
+Open http://localhost:16686 → search service **pypepper**.
+
+## Correlation with request_id
+
+HTTP access logs still use `X-Request-ID` / `log.request_id()`. The same value is set as span attribute `request_id` so you can join logs and traces.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ nav:
       - Event and FSM: guides/event-fsm.md
       - Scheduler: guides/scheduler.md
       - Network and SSE: guides/network-sse.md
+      - Tracing: guides/tracing.md
       - DB Helper: guides/helper-db.md
 
 markdown_extensions:

--- a/pypepper/common/config.py
+++ b/pypepper/common/config.py
@@ -76,12 +76,25 @@ class ConfSSE:
     rateLimit: ConfSSERateLimit
 
 
+class ConfTracingOTLP:
+    enabled: bool
+    endpoint: str
+
+
+class ConfTracing:
+    enabled: bool
+    serviceName: str
+    console: bool
+    otlp: ConfTracingOTLP
+
+
 class YmlConfig:
     cluster: ConfCluster
     network: ConfNetwork
     heartbeat: ConfHeartbeat
     log: ConfLog
     sse: ConfSSE
+    tracing: ConfTracing
     custom: Any
 
 
@@ -123,6 +136,10 @@ class Config:
         if hasattr(self.get_yml_config(), "log") and hasattr(self.get_yml_config().log, "level"):
             log.set_log_level(self.get_yml_config().log.level)
             log.set_colorize(self.get_yml_config().log.colorize)
+
+        from pypepper.common.tracing import setup_from_config
+
+        setup_from_config(self.get_yml_config())
 
     def get_yml_config(self) -> YmlConfig:
         return self._setting

--- a/pypepper/common/system.py
+++ b/pypepper/common/system.py
@@ -17,6 +17,9 @@ def shutdown():
     :return: None
     """
 
+    from pypepper.common.tracing import shutdown as tracing_shutdown
+
+    tracing_shutdown()
     log.close()
     print(f"[{time.get_local_datetime()}] ### Logger close done.")
     os.abort()

--- a/pypepper/common/tracing/__init__.py
+++ b/pypepper/common/tracing/__init__.py
@@ -1,0 +1,10 @@
+from pypepper.common.tracing.middleware import TracingMiddleware
+from pypepper.common.tracing.setup import get_tracer, setup_for_tests, setup_from_config, shutdown
+
+__all__ = [
+    "TracingMiddleware",
+    "get_tracer",
+    "setup_for_tests",
+    "setup_from_config",
+    "shutdown",
+]

--- a/pypepper/common/tracing/middleware.py
+++ b/pypepper/common/tracing/middleware.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from opentelemetry.trace import SpanKind, Status, StatusCode
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+from pypepper.common.tracing.setup import get_tracer
+
+
+class TracingMiddleware(BaseHTTPMiddleware):
+    """Create a SERVER span per HTTP request; attach request_id when present."""
+
+    def __init__(self, app: ASGIApp, tracer_name: str = "pypepper.network.http"):
+        super().__init__(app)
+        self._tracer_name = tracer_name
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        tracer = get_tracer(self._tracer_name)
+        span_name = f"{request.method} {request.url.path}"
+        with tracer.start_as_current_span(span_name, kind=SpanKind.SERVER) as span:
+            span.set_attribute("http.method", request.method)
+            span.set_attribute("http.scheme", request.url.scheme)
+            span.set_attribute("url.path", request.url.path)
+            if request.url.query:
+                span.set_attribute("url.query", request.url.query)
+
+            try:
+                response = await call_next(request)
+            except Exception as exc:
+                span.set_status(Status(StatusCode.ERROR, str(exc)))
+                span.record_exception(exc)
+                raise
+
+            req_id = getattr(request.state, "request_id", None)
+            if req_id is not None:
+                span.set_attribute("request_id", str(req_id))
+
+            span.set_attribute("http.status_code", response.status_code)
+            if response.status_code >= 500:
+                span.set_status(Status(StatusCode.ERROR))
+            return response

--- a/pypepper/common/tracing/setup.py
+++ b/pypepper/common/tracing/setup.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import atexit
+from typing import Any
+
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+from opentelemetry.util._once import Once
+
+_provider: TracerProvider | None = None
+_atexit_registered = False
+
+
+def get_tracer(name: str = "pypepper") -> trace.Tracer:
+    """Return a tracer from the global provider (no-op when tracing is disabled)."""
+    return trace.get_tracer(name)
+
+
+def _allow_tracer_provider_override() -> None:
+    """Reset the global once-flag so tests / reload can replace the provider."""
+    trace._TRACER_PROVIDER_SET_ONCE = Once()
+    trace._TRACER_PROVIDER = None
+
+
+def shutdown() -> None:
+    """Flush and shut down the configured TracerProvider, if any."""
+    global _provider
+    if _provider is not None:
+        _provider.force_flush()
+        _provider.shutdown()
+        _provider = None
+    _allow_tracer_provider_override()
+    trace.set_tracer_provider(trace.NoOpTracerProvider())
+
+
+def setup_from_config(yml_config: Any | None = None) -> None:
+    """
+    Configure OpenTelemetry from YAML config.
+
+    Expected shape (all optional; missing section disables tracing)::
+
+        tracing:
+          enabled: false
+          serviceName: pypepper
+          console: false
+          otlp:
+            enabled: false
+            endpoint: http://127.0.0.1:4318
+    """
+    global _provider, _atexit_registered
+
+    shutdown()
+
+    if yml_config is None or not hasattr(yml_config, "tracing"):
+        return
+
+    tracing_cfg = yml_config.tracing
+    if tracing_cfg is None:
+        return
+
+    enabled = bool(getattr(tracing_cfg, "enabled", False))
+    if not enabled:
+        return
+
+    service_name = getattr(tracing_cfg, "serviceName", None)
+    if not service_name and hasattr(yml_config, "serviceInfo"):
+        service_name = getattr(yml_config.serviceInfo, "serviceName", None)
+    if not service_name:
+        service_name = "pypepper"
+
+    console = bool(getattr(tracing_cfg, "console", False))
+    otlp_cfg = getattr(tracing_cfg, "otlp", None)
+    otlp_enabled = bool(getattr(otlp_cfg, "enabled", False)) if otlp_cfg is not None else False
+    otlp_endpoint = (getattr(otlp_cfg, "endpoint", None) if otlp_cfg is not None else None) or "http://127.0.0.1:4318"
+
+    if not console and not otlp_enabled:
+        return
+
+    resource = Resource.create({"service.name": service_name})
+    provider = TracerProvider(resource=resource)
+
+    if console:
+        # Simple processor so spans appear promptly in the terminal during local demos.
+        provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+
+    if otlp_enabled:
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+        endpoint = str(otlp_endpoint).rstrip("/")
+        if not endpoint.endswith("/v1/traces"):
+            endpoint = f"{endpoint}/v1/traces"
+        # Simple processor so local Jaeger UI sees spans without waiting for a batch flush.
+        exporter = OTLPSpanExporter(endpoint=endpoint)
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    _allow_tracer_provider_override()
+    trace.set_tracer_provider(provider)
+    _provider = provider
+
+    if not _atexit_registered:
+        atexit.register(shutdown)
+        _atexit_registered = True
+
+
+def setup_for_tests(exporter: Any, service_name: str = "pypepper-test") -> TracerProvider:
+    """
+    Install a TracerProvider that exports to the given span exporter (tests only).
+
+    Uses SimpleSpanProcessor so spans are available immediately after the request.
+    """
+    global _provider
+    shutdown()
+    resource = Resource.create({"service.name": service_name})
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    _allow_tracer_provider_override()
+    trace.set_tracer_provider(provider)
+    _provider = provider
+    return provider

--- a/pypepper/network/http/handlers/handlers.py
+++ b/pypepper/network/http/handlers/handlers.py
@@ -37,7 +37,12 @@ class BaseHandlers(ITaskHandler):
         app.get("/metrics")(metrics)
 
     def _use_default_middleware(self, app: FastAPI):
+        # Starlette runs last-added middleware first. Tracing is outer; RequestId runs
+        # inside the span so request_id is available after call_next.
         app.add_middleware(RequestIdMiddleware)
+        from pypepper.common.tracing import TracingMiddleware
+
+        app.add_middleware(TracingMiddleware)
 
 
 base_handlers = BaseHandlers()

--- a/pypepper/scheduler/workflow.py
+++ b/pypepper/scheduler/workflow.py
@@ -31,14 +31,17 @@ class Workflow(IWorkflow):
         Respects retry_count / retry_delay / optional.
         Non-optional task failure aborts the workflow.
         """
-        if len(self.tasks) == 0:
-            return []
+        from pypepper.common.tracing import get_tracer
 
-        results = []
-        for task in self.tasks:
-            result = self._run_task(task)
-            results.append(result)
-        return results
+        with get_tracer("pypepper.scheduler").start_as_current_span("scheduler.workflow.run"):
+            if len(self.tasks) == 0:
+                return []
+
+            results = []
+            for task in self.tasks:
+                result = self._run_task(task)
+                results.append(result)
+            return results
 
     def _run_task(self, task: Task):
         attempts = max(1, int(task.retry_count or 0) + 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ dependencies = [
     "pyyaml==6.0.3",
     "sqlalchemy==2.0.51",
     "pip==26.1.2",
+    "opentelemetry-api==1.43.0",
+    "opentelemetry-sdk==1.43.0",
+    "opentelemetry-exporter-otlp-proto-http==1.43.0",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ pymysql==1.2.0
 psycopg[binary]==3.3.4
 pyyaml==6.0.3
 sqlalchemy==2.0.51
+opentelemetry-api==1.43.0
+opentelemetry-sdk==1.43.0
+opentelemetry-exporter-otlp-proto-http==1.43.0

--- a/tests/common/test_tracing_setup.py
+++ b/tests/common/test_tracing_setup.py
@@ -74,16 +74,36 @@ def test_setup_enabled_without_exporters_is_noop():
     shutdown()
 
 
-def test_setup_console_configures_provider():
+def test_setup_service_name_fallback_and_default():
     setup_from_config(
         SimpleNamespace(
             tracing=SimpleNamespace(
                 enabled=True,
-                serviceName="console-cfg",
+                serviceName=None,
+                console=True,
+                otlp=SimpleNamespace(enabled=False, endpoint="http://127.0.0.1:4318"),
+            ),
+            serviceInfo=SimpleNamespace(serviceName="from-service-info"),
+        )
+    )
+    assert trace.get_tracer_provider().__class__.__name__ == "TracerProvider"
+    shutdown()
+
+    setup_from_config(
+        SimpleNamespace(
+            tracing=SimpleNamespace(
+                enabled=True,
+                serviceName=None,
                 console=True,
                 otlp=SimpleNamespace(enabled=False, endpoint="http://127.0.0.1:4318"),
             )
         )
     )
     assert trace.get_tracer_provider().__class__.__name__ == "TracerProvider"
+    shutdown()
+
+
+def test_setup_tracing_cfg_none():
+    setup_from_config(SimpleNamespace(tracing=None))
+    assert isinstance(trace.get_tracer_provider(), trace.NoOpTracerProvider)
     shutdown()

--- a/tests/common/test_tracing_setup.py
+++ b/tests/common/test_tracing_setup.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from pypepper.common.tracing import setup_for_tests, setup_from_config, shutdown
+
+
+def test_setup_from_config_missing_section_disables():
+    setup_from_config(SimpleNamespace())
+    assert isinstance(trace.get_tracer_provider(), trace.NoOpTracerProvider)
+    shutdown()
+
+
+def test_setup_from_config_enabled_false():
+    setup_from_config(
+        SimpleNamespace(
+            tracing=SimpleNamespace(
+                enabled=False,
+                serviceName="x",
+                console=True,
+                otlp=SimpleNamespace(enabled=False, endpoint="http://127.0.0.1:4318"),
+            )
+        )
+    )
+    assert isinstance(trace.get_tracer_provider(), trace.NoOpTracerProvider)
+    shutdown()
+
+
+def test_setup_for_tests_exports_spans():
+    exporter = InMemorySpanExporter()
+    setup_for_tests(exporter, service_name="console-test")
+    tracer = trace.get_tracer("t")
+    with tracer.start_as_current_span("console-span"):
+        pass
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == "console-span"
+    shutdown()
+
+
+def test_setup_otlp_configures_provider_without_network():
+    """OTLP exporter is constructed; do not emit spans (would retry against :4318)."""
+    setup_from_config(
+        SimpleNamespace(
+            tracing=SimpleNamespace(
+                enabled=True,
+                serviceName="otlp-test",
+                console=False,
+                otlp=SimpleNamespace(enabled=True, endpoint="http://127.0.0.1:4318"),
+            ),
+            serviceInfo=SimpleNamespace(serviceName="fallback"),
+        )
+    )
+    provider = trace.get_tracer_provider()
+    assert provider.__class__.__name__ == "TracerProvider"
+    shutdown()
+
+
+def test_setup_enabled_without_exporters_is_noop():
+    setup_from_config(
+        SimpleNamespace(
+            tracing=SimpleNamespace(
+                enabled=True,
+                serviceName="noop",
+                console=False,
+                otlp=SimpleNamespace(enabled=False, endpoint="http://127.0.0.1:4318"),
+            )
+        )
+    )
+    assert isinstance(trace.get_tracer_provider(), trace.NoOpTracerProvider)
+    shutdown()
+
+
+def test_setup_console_configures_provider():
+    setup_from_config(
+        SimpleNamespace(
+            tracing=SimpleNamespace(
+                enabled=True,
+                serviceName="console-cfg",
+                console=True,
+                otlp=SimpleNamespace(enabled=False, endpoint="http://127.0.0.1:4318"),
+            )
+        )
+    )
+    assert trace.get_tracer_provider().__class__.__name__ == "TracerProvider"
+    shutdown()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pypepper.common.cache import Cache
+from pypepper.common.tracing import shutdown as tracing_shutdown
 from pypepper.loader import loader
 from pypepper.network.http.sse.connection import connection_manager
 from pypepper.network.http.sse.security import SSESecurityManager
@@ -24,7 +25,11 @@ def _reset_global_registries():
     # SSE rate-limit cache
     SSESecurityManager._rate_limit_cache = Cache(maxsize=1000, ttl=60)
 
+    tracing_shutdown()
+
     yield
+
+    tracing_shutdown()
 
     with connection_manager._lock:
         connection_manager._connections.clear()

--- a/tests/network/http/test_tracing_middleware.py
+++ b/tests/network/http/test_tracing_middleware.py
@@ -32,3 +32,52 @@ def test_http_middleware_creates_server_span_with_request_id():
     assert span.attributes.get("http.status_code") == 200
 
     shutdown()
+
+
+def test_http_middleware_records_query_and_server_error():
+    exporter = InMemorySpanExporter()
+    setup_for_tests(exporter, service_name="http-error-test")
+
+    app = FastAPI()
+
+    @app.get("/boom")
+    def boom():
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse({"ok": False}, status_code=500)
+
+    handlers.use_middleware(app)
+    client = TestClient(app)
+    response = client.get("/boom?x=1", headers={"X-Request-ID": "req-err"})
+    assert response.status_code == 500
+
+    spans = [s for s in exporter.get_finished_spans() if s.name.startswith("GET ")]
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.attributes.get("url.query") == "x=1"
+    assert span.attributes.get("http.status_code") == 500
+    assert span.attributes.get("request_id") == "req-err"
+
+    shutdown()
+
+
+def test_http_middleware_records_unhandled_exception():
+    exporter = InMemorySpanExporter()
+    setup_for_tests(exporter, service_name="http-exc-test")
+
+    app = FastAPI()
+
+    @app.get("/raise")
+    def raise_it():
+        raise RuntimeError("explode")
+
+    handlers.use_middleware(app)
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/raise", headers={"X-Request-ID": "req-raise"})
+    assert response.status_code == 500
+
+    spans = [s for s in exporter.get_finished_spans() if s.name.startswith("GET ")]
+    assert len(spans) == 1
+    assert spans[0].status.status_code.name == "ERROR"
+
+    shutdown()

--- a/tests/network/http/test_tracing_middleware.py
+++ b/tests/network/http/test_tracing_middleware.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from starlette.testclient import TestClient
+
+from pypepper.common.tracing import setup_for_tests, shutdown
+from pypepper.network.http.handlers import handlers
+
+
+def test_http_middleware_creates_server_span_with_request_id():
+    exporter = InMemorySpanExporter()
+    setup_for_tests(exporter, service_name="http-test")
+
+    app = FastAPI()
+    handlers.register_handlers(app)
+    handlers.use_middleware(app)
+
+    client = TestClient(app)
+    response = client.get("/health", headers={"X-Request-ID": "req-trace-1"})
+    assert response.status_code == 200
+    assert response.headers.get("X-Request-ID") == "req-trace-1"
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) >= 1
+    http_spans = [s for s in spans if s.name.startswith("GET ")]
+    assert len(http_spans) == 1
+    span = http_spans[0]
+    assert span.attributes.get("http.method") == "GET"
+    assert span.attributes.get("url.path") == "/health"
+    assert span.attributes.get("request_id") == "req-trace-1"
+    assert span.attributes.get("http.status_code") == 200
+
+    shutdown()

--- a/tests/scheduler/test_workflow_tracing.py
+++ b/tests/scheduler/test_workflow_tracing.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from pypepper.common.tracing import setup_for_tests, shutdown
+from pypepper.scheduler.executor import CallableExecutor
+from pypepper.scheduler.task import Task
+from pypepper.scheduler.workflow import Workflow
+
+
+def test_workflow_run_creates_span():
+    exporter = InMemorySpanExporter()
+    setup_for_tests(exporter, service_name="workflow-test")
+
+    def _run(task, context):
+        return "ok"
+
+    task = Task(
+        channel_id="c",
+        dag_id="d",
+        fingerprint="f",
+        name="t",
+        category="c",
+        description="",
+        tags=[],
+        executor=CallableExecutor(_run),
+    )
+    workflow = Workflow()
+    workflow.add_task(task)
+    assert workflow.run() == ["ok"]
+
+    spans = exporter.get_finished_spans()
+    names = [s.name for s in spans]
+    assert "scheduler.workflow.run" in names
+
+    shutdown()

--- a/uv.lock
+++ b/uv.lock
@@ -573,6 +573,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1192,6 +1204,87 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/cc/e4c9584181f86494df0f6bdec1a4f3280c50db44704dc2a407e994fc87bb/opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1", size = 73476, upload-time = "2026-06-24T15:19:55.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/83/6dba32b85f31868400440dc7ad2ca1eab94cbbf3a7b0459ed39f8311a9e2/opentelemetry_api-1.43.0-py3-none-any.whl", hash = "sha256:20acf45e9b21851926835292e4045d290acade1edd2ff3de86d2f069687ba1fd", size = 61912, upload-time = "2026-06-24T15:19:35.434Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/c1/e8098490ab15abf116dcaf9fa89ededcb35547c7d08d4b5a62f573dc1e63/opentelemetry_exporter_otlp_proto_common-1.43.0.tar.gz", hash = "sha256:c4e32ba6d6b13bdb2b8f6764c4fd28d00192826561aa04f6d14eedfce7ac076f", size = 20197, upload-time = "2026-06-24T15:20:00.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/b2/41ebc74ae1d5859901f1b69305de58724bf043381103d6ef413521cbc35a/opentelemetry_exporter_otlp_proto_common-1.43.0-py3-none-any.whl", hash = "sha256:123c3f9cc87218562490c63b36f497bf3a722faf174a515d1443f31ababa6264", size = 17048, upload-time = "2026-06-24T15:19:41.264Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/92/0b9f56412483a8891d4843890294796c9df8ab42417bd9bad8035d840cb3/opentelemetry_exporter_otlp_proto_http-1.43.0.tar.gz", hash = "sha256:fa8a42bb7d00ee5391f4c0b04d8e6a46c03caa437903296ab73a81dc11ba118f", size = 25406, upload-time = "2026-06-24T15:20:01.515Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/20/b685ed7af2e17c29ffc8af56f1fa8bc2033258fc30fb0d2b722f49d13ba0/opentelemetry_exporter_otlp_proto_http-1.43.0-py3-none-any.whl", hash = "sha256:647f603aa8efdbdb4dbff842e0729d0406a6fff26b295a72d3d60e7d963b2610", size = 21795, upload-time = "2026-06-24T15:19:43.164Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b9/d357faefb40bda1d4799913e6af611171ff22a2dedcb93576bc92242d056/opentelemetry_proto-1.43.0.tar.gz", hash = "sha256:224778df17e1f3fafeaaa21d874236ca5f6ffc2f86e0899298ec7351aac27924", size = 46481, upload-time = "2026-06-24T15:20:07.625Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/a7/3e5308cf548b8f72529c7db1afdb3a404211982376a12927fd7759f77bf3/opentelemetry_proto-1.43.0-py3-none-any.whl", hash = "sha256:c58f1f7ef84bc7dc2834016c0c37fe0081dde7ca9f6339be1970fbf9cdaaa90d", size = 72489, upload-time = "2026-06-24T15:19:51.164Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/eb/5041074274ac0956b03637cc039d434569112468e875eddfcc9a0674ce06/opentelemetry_sdk-1.43.0.tar.gz", hash = "sha256:d8187c81c162df9913e4003dd6485f7390d9a24fc17026ec7387b8b8218b08e9", size = 254744, upload-time = "2026-06-24T15:20:08.467Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/e3/b17be23af124201c9f52eececd4cc8ddfed1597d37b4ee771895d325805c/opentelemetry_sdk-1.43.0-py3-none-any.whl", hash = "sha256:d1323a547c1ce69d6a069a17a44b7da82bb8b332051ecb074041f87642c86823", size = 178852, upload-time = "2026-06-24T15:19:52.169Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/30/5f26df29509eccd86b99b481ac9ffa39da49ba9577cc69071c552ae30447/opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c", size = 148340, upload-time = "2026-06-24T15:20:09.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/ca/23ba87a221b574a7c5a99d48849d80bfe8b047624681357e2b002e566187/opentelemetry_semantic_conventions-0.64b0-py3-none-any.whl", hash = "sha256:ea77e85e354b8f604ddbe5f3d9135216f982fa4d77e5859ac30f6d8a50505aa6", size = 203713, upload-time = "2026-06-24T15:19:53.339Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1243,6 +1336,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
 ]
 
 [[package]]
@@ -1580,6 +1688,9 @@ dependencies = [
     { name = "fastapi" },
     { name = "loguru" },
     { name = "mongoengine" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
     { name = "pip" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pymysql" },
@@ -1614,6 +1725,9 @@ requires-dist = [
     { name = "fastapi", specifier = "==0.139.0" },
     { name = "loguru", specifier = "==0.7.3" },
     { name = "mongoengine", specifier = "==0.29.3" },
+    { name = "opentelemetry-api", specifier = "==1.43.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = "==1.43.0" },
+    { name = "opentelemetry-sdk", specifier = "==1.43.0" },
     { name = "pip", specifier = "==26.1.2" },
     { name = "psycopg", extras = ["binary"], specifier = "==3.3.4" },
     { name = "pymysql", specifier = "==1.2.0" },


### PR DESCRIPTION
## Summary

- Problem: Roadmap Tracing was unchecked; only `request_id` logs existed, with no exportable spans or UI.
- Why it matters: Local/dev debugging needs correlatable traces in the terminal and optionally Jaeger.
- What changed: Opt-in OpenTelemetry (`tracing` YAML, default off), Console + OTLP HTTP exporters, HTTP `TracingMiddleware` + `Workflow.run` spans, Jaeger in `devenv/dev.yaml` only, docs/tests/Roadmap.
- What did NOT change: No FSM/SSE deep spans, no Jaeger in CI, no version bump / PyPI release.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] common
- [ ] event
- [ ] fsm
- [ ] helper
- [x] network
- [x] scheduler
- [x] CI/CD / infra

## Linked Issue/PR

- Related: Roadmap Tracing (P1)

## User-visible / Behavior Changes

- New optional `tracing` config (default disabled).
- When enabled: console span output and/or OTLP export to `endpoint` (local Jaeger `:4318`).
- HTTP requests and `Workflow.run` emit spans; `request_id` attached as span attribute.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes` — only when `tracing.otlp.enabled`; exports spans to configured OTLP HTTP endpoint)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: OTLP is off by default; intended for local/dev Jaeger; do not point at untrusted collectors in production without review.

## Repro + Verification

### Environment

- OS: Linux
- Runtime: local `.venv`, `jaegertracing/all-in-one:1.76.0`

### Steps

1. Enable `tracing.enabled` + `console` + `otlp` in a temp YAML
2. `docker compose -f devenv/dev.yaml up -d jaeger` (or equivalent `docker run`)
3. `python example/server/app.py --config <temp.yaml>`
4. `curl -H 'X-Request-ID: manual-1' http://127.0.0.1:<port>/health`

### Expected

- Terminal shows SERVER span with `request_id`
- Jaeger UI (`http://localhost:16686`) shows service `pypepper` / `GET /health`

### Actual

- Verified locally: console span + Jaeger API `traceCount >= 1` for service `pypepper`

## Evidence

- [x] Unit tests (`InMemorySpanExporter`) for setup / HTTP middleware / workflow
- [x] Local console + Jaeger all-in-one:1.76.0 verification
- [x] `make lint` / `make docs` green locally

## Human Verification (required)

- Verified scenarios: console exporter; OTLP → Jaeger UI/API; default-off config
- Edge cases checked: enabled without exporters stays no-op; provider reload in tests
- What you did **not** verify: production Collector; FSM/SSE span coverage; full `make test` DB matrix in this session

## Compatibility / Migration

- Backward compatible? (`Yes` — tracing off by default)
- Config/env changes? (`Yes` — optional `tracing` section)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert: set `tracing.enabled: false` or omit section / revert PR
- Files/config to restore: `pypepper/common/tracing/`, config hook, middleware registration
- Known bad symptoms: unexpected OTLP connection attempts if misconfigured `otlp.enabled`

## Risks and Mitigations

- Risk: OTLP export to wrong endpoint when misconfigured
  - Mitigation: default off; docs emphasize local Jaeger only
- Risk: OpenTelemetry global provider once-semantics in tests
  - Mitigation: controlled reset helper + conftest shutdown

## Test plan

- [x] Unit tests without Docker
- [x] Manual console + Jaeger UI
- [ ] CI green on this PR