### PR TITLE
docs: add mkdocstrings API reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Tighten mypy on TOP3 static paths (`crypto`, HTTP/SSE skeleton, scheduler structure) with `disallow_untyped_defs` + `warn_return_any` (scoped overrides; dynamic/third-party modules unchanged).
 
 ### Added
+- MkDocs API Reference via `mkdocstrings` (`docs/reference/`, curated public modules).
 - OpenTelemetry tracing (opt-in via `tracing` YAML): console exporter and OTLP HTTP to local Jaeger; HTTP + `Workflow.run` spans.
 - `py.typed` PEP 561 marker and `Typing :: Typed` classifier (typed package for consumers after next PyPI release).
 - `Event.marshal()` JSON envelope.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -77,4 +77,5 @@ Push to `main` deploys the site via GitHub Pages (`.github/workflows/docs.yml`).
 
 - Read [Architecture](architecture.md) for module boundaries
 - Follow a domain guide under **Guides**
+- Browse the [API Reference](reference/index.md) for signatures and types
 - Optional: enable [Tracing](guides/tracing.md) (console and/or local Jaeger)

--- a/docs/guides/common.md
+++ b/docs/guides/common.md
@@ -84,3 +84,5 @@ print(uuid.new_uuid())
 
 result = run(lambda: 1 + 1, retry_times=3, retry_interval=0)
 ```
+
+See also: [API Reference / Common](../reference/common.md).

--- a/docs/guides/event-fsm.md
+++ b/docs/guides/event-fsm.md
@@ -69,3 +69,5 @@ assert resp.error is not None
 ```
 
 Unknown transitions return `Response.error` without raising.
+
+See also: [API Reference / Event and FSM](../reference/event-fsm.md).

--- a/docs/guides/helper-db.md
+++ b/docs/guides/helper-db.md
@@ -66,3 +66,5 @@ mongodb.close()
 
 !!! tip
     Prefer environment-specific secrets outside the repo. The devenv passwords are for local/CI only.
+
+See also: [API Reference / DB Helper](../reference/helper.md).

--- a/docs/guides/network-sse.md
+++ b/docs/guides/network-sse.md
@@ -82,3 +82,5 @@ export PYPEPPER_SSE_API_KEY=your-local-key
 python example/sse/app.py
 curl -N -H "X-API-Key: $PYPEPPER_SSE_API_KEY" http://localhost:55550/sse/echo
 ```
+
+See also: [API Reference / Network and SSE](../reference/network.md).

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -76,3 +76,5 @@ Each `Job` owns an FSM from `build_scheduler_fsm()`:
 ## Persistence stub
 
 `Job.save()` currently logs only; there is no durable job store.
+
+See also: [API Reference / Scheduler](../reference/scheduler.md).

--- a/docs/guides/tracing.md
+++ b/docs/guides/tracing.md
@@ -82,3 +82,5 @@ Open http://localhost:16686 → search service **pypepper**.
 ## Correlation with request_id
 
 HTTP access logs still use `X-Request-ID` / `log.request_id()`. The same value is set as span attribute `request_id` so you can join logs and traces.
+
+See also: [API Reference / Common](../reference/common.md) (tracing section).

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ Published docs: <https://jovijovi.github.io/pypepper/>
 1. [Getting Started](getting-started.md) — install, test, run examples
 2. [Architecture](architecture.md) — layering, extension points, singletons
 3. Domain guides under **Guides** for copy-paste snippets
+4. [API Reference](reference/index.md) — generated signatures and docstrings
 
 ## Examples
 

--- a/docs/reference/common.md
+++ b/docs/reference/common.md
@@ -1,0 +1,35 @@
+# Common
+
+Shared kernel used by other domains. Narrative guide: [Common](../guides/common.md). Tracing how-to: [Tracing](../guides/tracing.md).
+
+## Config
+
+::: pypepper.common.config
+
+## Log
+
+::: pypepper.common.log
+
+## Options
+
+::: pypepper.common.options
+
+## Context
+
+::: pypepper.common.context
+
+## Cache
+
+::: pypepper.common.cache
+
+## Tracing
+
+::: pypepper.common.tracing
+
+## Crypto
+
+::: pypepper.common.security.crypto.digest
+
+::: pypepper.common.security.crypto.salt
+
+::: pypepper.common.security.crypto.elliptic.ecdsa

--- a/docs/reference/event-fsm.md
+++ b/docs/reference/event-fsm.md
@@ -1,0 +1,11 @@
+# Event and FSM
+
+Signed domain events and an event-triggered finite state machine. Narrative guide: [Event and FSM](../guides/event-fsm.md).
+
+## Event
+
+::: pypepper.event.event
+
+## FSM
+
+::: pypepper.fsm.fsm

--- a/docs/reference/helper.md
+++ b/docs/reference/helper.md
@@ -1,0 +1,19 @@
+# DB Helper
+
+Thin database connectors. Narrative guide: [DB Helper](../guides/helper-db.md).
+
+## Interfaces
+
+::: pypepper.helper.db.interfaces
+
+## MySQL
+
+::: pypepper.helper.db.mysql
+
+## PostgreSQL
+
+::: pypepper.helper.db.postgres
+
+## MongoDB
+
+::: pypepper.helper.db.mongodb

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,14 @@
+# API Reference
+
+Machine-generated reference from the `pypepper` package (signatures, types, and existing docstrings).
+
+| Section | Package focus |
+|---------|---------------|
+| [Common](common.md) | Config, log, context, cache, crypto, tracing |
+| [Event and FSM](event-fsm.md) | Signed events and finite state machines |
+| [Scheduler](scheduler.md) | Job pipeline: task, workflow, channel, worker |
+| [Network and SSE](network.md) | FastAPI HTTP server and SSE |
+| [DB Helper](helper.md) | MySQL, PostgreSQL, MongoDB connectors |
+| [Loader](loader.md) | Named module init hooks |
+
+For narrative how-tos, use the [Guides](../guides/common.md). For layering and singletons, see [Architecture](../architecture.md).

--- a/docs/reference/loader.md
+++ b/docs/reference/loader.md
@@ -1,0 +1,5 @@
+# Loader
+
+Named module registration and load hooks used at process startup.
+
+::: pypepper.loader

--- a/docs/reference/network.md
+++ b/docs/reference/network.md
@@ -1,0 +1,29 @@
+# Network and SSE
+
+FastAPI HTTP server and Server-Sent Events. Narrative guide: [Network and SSE](../guides/network-sse.md).
+
+## HTTP server
+
+::: pypepper.network.http.server
+
+## HTTP interfaces
+
+::: pypepper.network.http.interfaces
+
+## HTTP handlers
+
+::: pypepper.network.http.handlers.base
+
+::: pypepper.network.http.handlers.handlers
+
+## SSE
+
+::: pypepper.network.http.sse.connection
+
+::: pypepper.network.http.sse.stream
+
+::: pypepper.network.http.sse.handlers
+
+::: pypepper.network.http.sse.security
+
+::: pypepper.network.http.sse.event

--- a/docs/reference/scheduler.md
+++ b/docs/reference/scheduler.md
@@ -1,0 +1,31 @@
+# Scheduler
+
+Workflow-based job pipeline. Narrative guide: [Scheduler](../guides/scheduler.md).
+
+## Task
+
+::: pypepper.scheduler.task
+
+## Workflow
+
+::: pypepper.scheduler.workflow
+
+## Job
+
+::: pypepper.scheduler.job
+
+## Channel
+
+::: pypepper.scheduler.channel
+
+## Worker
+
+::: pypepper.scheduler.worker
+
+## Executor
+
+::: pypepper.scheduler.executor
+
+## Events
+
+::: pypepper.scheduler.events

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ theme:
   features:
     - navigation.sections
     - navigation.expand
+    - navigation.indexes
     - content.code.copy
     - toc.follow
 
@@ -28,6 +29,14 @@ nav:
       - Network and SSE: guides/network-sse.md
       - Tracing: guides/tracing.md
       - DB Helper: guides/helper-db.md
+  - API Reference:
+      - reference/index.md
+      - Common: reference/common.md
+      - Event and FSM: reference/event-fsm.md
+      - Scheduler: reference/scheduler.md
+      - Network and SSE: reference/network.md
+      - DB Helper: reference/helper.md
+      - Loader: reference/loader.md
 
 markdown_extensions:
   - admonition
@@ -46,3 +55,18 @@ markdown_extensions:
 
 plugins:
   - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [.]
+          options:
+            docstring_style: auto
+            filters: ["!^_"]
+            members_order: source
+            separate_signature: true
+            show_signature_annotations: true
+            show_source: true
+            show_root_heading: true
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            show_if_no_docstring: true

--- a/pypepper/common/cache.py
+++ b/pypepper/common/cache.py
@@ -1,3 +1,5 @@
+"""Thread-safe TTL cache set."""
+
 from __future__ import annotations
 
 from collections.abc import MutableMapping

--- a/pypepper/common/config.py
+++ b/pypepper/common/config.py
@@ -1,3 +1,5 @@
+"""YAML config loading and typed configuration models."""
+
 import argparse
 import os.path
 from typing import Any

--- a/pypepper/common/context/__init__.py
+++ b/pypepper/common/context/__init__.py
@@ -1,3 +1,5 @@
+"""Chained request/job context exports."""
+
 from pypepper.common.context.context import Context, born, new
 
 __all__ = ["Context", "new", "born"]

--- a/pypepper/common/context/context.py
+++ b/pypepper/common/context/context.py
@@ -1,3 +1,5 @@
+"""Chained context implementation."""
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/pypepper/common/log.py
+++ b/pypepper/common/log.py
@@ -1,3 +1,5 @@
+"""Loguru-based process logger helpers."""
+
 import getpass
 import json
 import socket

--- a/pypepper/common/options.py
+++ b/pypepper/common/options.py
@@ -1,3 +1,5 @@
+"""Functional options pattern helpers."""
+
 from __future__ import annotations
 
 from abc import ABCMeta

--- a/pypepper/common/security/crypto/digest.py
+++ b/pypepper/common/security/crypto/digest.py
@@ -1,3 +1,5 @@
+"""Hash digest helpers (bytes and hex)."""
+
 import hashlib
 
 BinaryLike = str | bytes | bytearray | memoryview

--- a/pypepper/common/security/crypto/elliptic/ecdsa.py
+++ b/pypepper/common/security/crypto/elliptic/ecdsa.py
@@ -1,3 +1,5 @@
+"""ECDSA sign and verify on secp256k1."""
+
 from cryptography import exceptions
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec

--- a/pypepper/common/security/crypto/salt.py
+++ b/pypepper/common/security/crypto/salt.py
@@ -1,3 +1,5 @@
+"""Random salt generation."""
+
 import secrets
 
 from pypepper.exceptions import InternalException

--- a/pypepper/common/tracing/__init__.py
+++ b/pypepper/common/tracing/__init__.py
@@ -1,3 +1,5 @@
+"""OpenTelemetry tracing setup and HTTP middleware exports."""
+
 from pypepper.common.tracing.middleware import TracingMiddleware
 from pypepper.common.tracing.setup import get_tracer, setup_for_tests, setup_from_config, shutdown
 

--- a/pypepper/common/tracing/middleware.py
+++ b/pypepper/common/tracing/middleware.py
@@ -1,3 +1,5 @@
+"""Starlette/FastAPI middleware that creates SERVER spans."""
+
 from __future__ import annotations
 
 from opentelemetry.trace import SpanKind, Status, StatusCode

--- a/pypepper/common/tracing/setup.py
+++ b/pypepper/common/tracing/setup.py
@@ -1,3 +1,5 @@
+"""Tracer provider setup, shutdown, and test helpers."""
+
 from __future__ import annotations
 
 import atexit

--- a/pypepper/event/event.py
+++ b/pypepper/event/event.py
@@ -1,3 +1,5 @@
+"""Signed domain events with JSON marshal."""
+
 from __future__ import annotations
 
 import base64

--- a/pypepper/fsm/fsm.py
+++ b/pypepper/fsm/fsm.py
@@ -1,3 +1,5 @@
+"""Event-triggered finite state machine with rollback."""
+
 from __future__ import annotations
 
 import json

--- a/pypepper/helper/db/interfaces.py
+++ b/pypepper/helper/db/interfaces.py
@@ -1,3 +1,5 @@
+"""Database helper configuration interfaces."""
+
 from __future__ import annotations
 
 from abc import ABCMeta

--- a/pypepper/helper/db/mongodb.py
+++ b/pypepper/helper/db/mongodb.py
@@ -1,3 +1,5 @@
+"""MongoDB / mongoengine connector helper."""
+
 from __future__ import annotations
 
 from abc import ABCMeta

--- a/pypepper/helper/db/mysql.py
+++ b/pypepper/helper/db/mysql.py
@@ -1,3 +1,5 @@
+"""MySQL SQLAlchemy connector helper."""
+
 from __future__ import annotations
 
 from abc import ABCMeta

--- a/pypepper/helper/db/postgres.py
+++ b/pypepper/helper/db/postgres.py
@@ -1,3 +1,5 @@
+"""PostgreSQL SQLAlchemy connector helper."""
+
 from __future__ import annotations
 
 from abc import ABCMeta

--- a/pypepper/loader.py
+++ b/pypepper/loader.py
@@ -1,3 +1,5 @@
+"""Named module loader registry singleton."""
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/pypepper/network/http/handlers/base.py
+++ b/pypepper/network/http/handlers/base.py
@@ -1,3 +1,5 @@
+"""Built-in health, ping, and metrics handlers."""
+
 from __future__ import annotations
 
 import time

--- a/pypepper/network/http/handlers/handlers.py
+++ b/pypepper/network/http/handlers/handlers.py
@@ -1,3 +1,5 @@
+"""Default HTTP handler registration and middleware."""
+
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable

--- a/pypepper/network/http/interfaces.py
+++ b/pypepper/network/http/interfaces.py
@@ -1,3 +1,5 @@
+"""HTTP task handler and middleware interfaces."""
+
 from abc import ABCMeta, abstractmethod
 
 from fastapi import FastAPI

--- a/pypepper/network/http/server.py
+++ b/pypepper/network/http/server.py
@@ -1,3 +1,5 @@
+"""FastAPI HTTP server run helpers (plain and TLS)."""
+
 import uvicorn
 from fastapi import FastAPI
 

--- a/pypepper/network/http/sse/connection.py
+++ b/pypepper/network/http/sse/connection.py
@@ -1,3 +1,5 @@
+"""SSE connection registry and limits."""
+
 from __future__ import annotations
 
 import asyncio

--- a/pypepper/network/http/sse/event.py
+++ b/pypepper/network/http/sse/event.py
@@ -1,3 +1,5 @@
+"""SSE event payload helpers."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/pypepper/network/http/sse/handlers.py
+++ b/pypepper/network/http/sse/handlers.py
@@ -1,3 +1,5 @@
+"""SSE route handlers."""
+
 from collections.abc import AsyncIterator
 
 from pypepper.network.http.sse.event import SSEEvent

--- a/pypepper/network/http/sse/security.py
+++ b/pypepper/network/http/sse/security.py
@@ -1,3 +1,5 @@
+"""SSE API key authentication helpers."""
+
 from collections.abc import Callable
 from functools import wraps
 from hmac import compare_digest

--- a/pypepper/network/http/sse/stream.py
+++ b/pypepper/network/http/sse/stream.py
@@ -1,3 +1,5 @@
+"""SSE streaming response helpers."""
+
 from __future__ import annotations
 
 import asyncio

--- a/pypepper/scheduler/channel.py
+++ b/pypepper/scheduler/channel.py
@@ -1,3 +1,5 @@
+"""Async job channels and channel manager."""
+
 from __future__ import annotations
 
 from asyncio import Queue, QueueFull

--- a/pypepper/scheduler/events.py
+++ b/pypepper/scheduler/events.py
@@ -1,3 +1,5 @@
+"""Scheduler FSM events and builder."""
+
 from pypepper.event import event
 from pypepper.event.event import Event
 from pypepper.fsm import fsm

--- a/pypepper/scheduler/executor.py
+++ b/pypepper/scheduler/executor.py
@@ -1,3 +1,5 @@
+"""Task executor interfaces and callable adapter."""
+
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod

--- a/pypepper/scheduler/job.py
+++ b/pypepper/scheduler/job.py
@@ -1,3 +1,5 @@
+"""Job model, processor, and dispatcher."""
+
 from __future__ import annotations
 
 import asyncio

--- a/pypepper/scheduler/task.py
+++ b/pypepper/scheduler/task.py
@@ -1,3 +1,5 @@
+"""Scheduler task data structures."""
+
 from abc import ABCMeta
 
 from pypepper.common.context import Context

--- a/pypepper/scheduler/worker.py
+++ b/pypepper/scheduler/worker.py
@@ -1,3 +1,5 @@
+"""Channel consumer that runs job workflows."""
+
 from __future__ import annotations
 
 import asyncio

--- a/pypepper/scheduler/workflow.py
+++ b/pypepper/scheduler/workflow.py
@@ -1,3 +1,5 @@
+"""Sequential workflow runner over tasks."""
+
 from __future__ import annotations
 
 import time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
     "coverage==7.15.1",
     "httpx>=0.28.1",
     "mkdocs-material>=9.6",
+    "mkdocstrings[python]>=0.29",
     "mypy==2.3.0",
     "packaging==26.2",
     "pip==26.1.2",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ build==1.5.1
 coverage==7.15.1
 httpx>=0.28.1
 mkdocs-material>=9.6
+mkdocstrings[python]>=0.29
 mypy==2.3.0
 packaging==26.2
 pip==26.1.2


### PR DESCRIPTION
## Summary

- Problem: Docs site had Guides/Architecture but no generated API surface for signatures and types.
- Why it matters: Library consumers need a browsable reference alongside narrative how-tos.
- What changed: Added `mkdocstrings[python]`, curated `docs/reference/` pages, MkDocs nav/plugin config (`show_if_no_docstring`), brief module docstrings on entry modules, cross-links from index/guides, CHANGELOG note.
- What did NOT change (scope boundary): No full Google-style docstring rewrite, no Sphinx, no PyPI release.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] common
- [x] event
- [x] fsm
- [x] helper
- [x] network
- [x] scheduler
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related # (P2 mkdocstrings API reference)

## User-visible / Behavior Changes

- New **API Reference** section on the MkDocs/GitHub Pages site after merge to `main`.
- Dev dependency: `mkdocstrings[python]>=0.29`.
- Runtime behavior of the library is unchanged (module docstrings only).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local `.venv` Python 3.13
- Relevant config (redacted): `mkdocs.yml` + `docs/reference/`

### Steps

1. `pip install -r requirements-dev.txt` (includes mkdocstrings)
2. `make docs`
3. Open `site/reference/` and confirm symbols render

### Expected

- `mkdocs build --strict` succeeds
- API Reference pages include public symbols (e.g. `Workflow`, `get_tracer`, `ECDSA`, `Loader`)

### Actual

- Matches expected locally

## Evidence

- [x] Trace/log snippets — `make docs` and `make lint` passed locally; HTML headings for `Workflow` / `get_tracer` / `ECDSA` / `Loader` present under `site/reference/`

## Human Verification (required)

- Verified scenarios: `make docs --strict`, `make lint`, spot-check generated HTML for key symbols; `show_if_no_docstring: true` required so undocumented classes still appear
- Edge cases checked: module docstring placement before `from __future__` (avoids ruff E402)
- What you did **not** verify: GitHub Pages deploy after merge; full visual browse of every reference page in a browser

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No` for runtime; yes for docs/dev deps)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR / remove mkdocstrings plugin from `mkdocs.yml`
- Files/config to restore: `mkdocs.yml`, `docs/reference/`, `requirements-dev.txt`
- Known bad symptoms reviewers should watch for: `make docs` / docs CI job failing on Griffe import errors

## Risks and Mitigations

- Risk: Docs CI fails if a curated module cannot be imported by Griffe
  - Mitigation: curated public surface only; `make docs --strict` already in lint/docs jobs
- Risk: Reference pages noisy without method-level docstrings
  - Mitigation: accepted for P2; signatures still render from type hints