### PR TITLE
ci: add coverage fail_under gate and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      production:
+        dependency-type: production
+      development:
+        dependency-type: development
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,7 +66,7 @@ jobs:
         run: python ./scripts/check_mutable_class_attrs.py
 
       - name: Test with coverage
-        run: pytest --cov=pypepper --cov-report=xml:coverage.xml --cov-report=term tests/
+        run: pytest --cov=pypepper --cov-report=xml:coverage.xml --cov-report=term --cov-fail-under=90 tests/
 
       - name: Stop devenv
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 - Tighten mypy on TOP3 static paths (`crypto`, HTTP/SSE skeleton, scheduler structure) with `disallow_untyped_defs` + `warn_return_any` (scoped overrides; dynamic/third-party modules unchanged).
 
 ### Added
+- Coverage gate: `fail_under = 90` / `--cov-fail-under=90` on local `make test` and CI.
+- Dependabot weekly updates for pip (`requirements*.txt` / `pyproject.toml`) and GitHub Actions (not Docker images).
 - MkDocs API Reference via `mkdocstrings` (`docs/reference/`, curated public modules).
 - OpenTelemetry tracing (opt-in via `tracing` YAML): console exporter and OTLP HTTP to local Jaeger; HTTP + `Workflow.run` spans.
 - `py.typed` PEP 561 marker and `Typing :: Typed` classifier (typed package for consumers after next PyPI release).

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ check: lint
 
 test: clean check
 	@echo "[BUILD] Testing"
-	pytest --cov=pypepper --cov-report=xml:coverage.xml --cov-report=term tests/
+	pytest --cov=pypepper --cov-report=xml:coverage.xml --cov-report=term --cov-fail-under=90 tests/
 
 build: build-prepare
 	@echo "[BUILD] Building binary"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,7 +25,7 @@ uv pip install -r requirements.txt
 ```shell
 make lint    # ruff + mypy on pypepper/
 make check   # lint + mutable class-attr guard
-make test    # check + pytest with coverage
+make test    # check + pytest with coverage (line coverage must be >= 90%)
 ```
 
 DB-backed helper tests expect services from `devenv/ci.yaml` on localhost:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,15 @@ dev = [
     "types-PyYAML>=6.0",
 ]
 
+[tool.coverage.run]
+source = ["pypepper"]
+branch = false
+
+[tool.coverage.report]
+fail_under = 90
+show_missing = true
+skip_covered = false
+
 [tool.ruff]
 target-version = "py310"
 line-length = 120


### PR DESCRIPTION
## Summary

- Problem: Coverage stayed high (~92%) but could regress silently; dependency bumps were manual.
- Why it matters: Hard gates keep quality from drifting; Dependabot reduces stale deps and Actions versions.
- What changed: `fail_under = 90` in `pyproject.toml`, `--cov-fail-under=90` in `Makefile` + CI, `.github/dependabot.yml` (weekly pip with production/development groups + github-actions), CHANGELOG + getting-started note.
- What did NOT change (scope boundary): No Codecov patch gate, no Docker image Dependabot, no business logic or extra tests to raise coverage.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] common
- [ ] event
- [ ] fsm
- [ ] helper
- [ ] network
- [ ] scheduler
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related # (P2 coverage fail_under + Dependabot)

## User-visible / Behavior Changes

- `make test` / CI pytest fail when line coverage is below 90%.
- Dependabot will open weekly PRs for pip and GitHub Actions (not Docker images).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local `.venv` + `devenv/ci.yaml` DBs
- Relevant config (redacted): `pyproject.toml` coverage + `dependabot.yml`

### Steps

1. `pytest --cov=pypepper --cov-report=term --cov-fail-under=90 tests/`
2. Same with `--cov-fail-under=99`

### Expected

- 90: coverage gate passes (~92%)
- 99: coverage gate fails

### Actual

- Matches expected (`Required test coverage of 90% reached` / `FAIL ... 99%`)

## Evidence

- [x] Trace/log snippets — local pytest-cov messages for 90 pass / 99 fail

## Human Verification (required)

- Verified scenarios: cov-fail-under 90 vs 99; `dependabot.yml` YAML parse
- Edge cases checked: N/A for Docker (explicitly out of scope)
- What you did **not** verify: first Dependabot PR after merge; full GitHub Actions run on this branch before review

## Compatibility / Migration

- Backward compatible? (`Yes` for runtime)
- Config/env changes? (`Yes` — CI/local test now enforce 90% coverage)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert PR, or lower/remove `--cov-fail-under` / `fail_under`
- Files/config to restore: `pyproject.toml`, `Makefile`, `.github/workflows/test.yaml`, `.github/dependabot.yml`
- Known bad symptoms reviewers should watch for: CI red solely due to coverage dip below 90%

## Risks and Mitigations

- Risk: Legitimate refactors temporarily dip under 90%
  - Mitigation: threshold set below current ~92% with ~2% margin; add tests or temporarily adjust only if needed
- Risk: Dependabot noise
  - Mitigation: weekly schedule, PR limit 5, pip production/development groups