### PR TITLE
docs+ci: refresh README and tag publish to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: Publish to PyPI
+
+"on":
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Use python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Verify tag matches pyproject version
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG_VERSION="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')"
+          echo "tag=${TAG} pyproject=${PKG_VERSION}"
+          if [ "${TAG}" != "${PKG_VERSION}" ]; then
+            echo "::error::Git tag v${TAG} does not match pyproject.toml version ${PKG_VERSION}"
+            exit 1
+          fi
+
+      - name: Install build
+        run: python -m pip install --upgrade pip build
+
+      - name: Build
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Protect example `/sse/stats` with API key auth.
 
 ### Changed
+- README refreshed as the project landing page (domains, highlights, quick start; details stay in MkDocs).
 - Event `sign`/`verify` use stable JSON canonical bytes instead of `pickle` (existing pickle signatures will not verify).
 - SSE connection/queue/stream limits read from YAML `sse.*` with hardcoded fallbacks.
 - HTTP server registers default request-id middleware and supports TLS via `certFile`/`keyFile`/`caFile`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Tighten mypy on TOP3 static paths (`crypto`, HTTP/SSE skeleton, scheduler structure) with `disallow_untyped_defs` + `warn_return_any` (scoped overrides; dynamic/third-party modules unchanged).
 
 ### Added
+- Tag-triggered PyPI publish workflow (`.github/workflows/publish.yml`) via Trusted Publisher when `v*` matches `pyproject.toml`.
 - Coverage gate: `fail_under = 90` / `--cov-fail-under=90` on local `make test` and CI.
 - Dependabot weekly updates for pip (`requirements*.txt` / `pyproject.toml`) and GitHub Actions (not Docker images).
 - MkDocs API Reference via `mkdocstrings` (`docs/reference/`, curated public modules).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.6.0
+
 ### Fixed
 - Isolate FSM transition tables per instance; `close()` only clears the current machine.
 - Roll back FSM state when a transition or caller handler raises.

--- a/README.md
+++ b/README.md
@@ -1,146 +1,90 @@
 <div align="center">
+  <img src="docs/logo/logo.svg" alt="PyPepper" width="128" />
 
-![logo](docs/logo/logo.svg)
+  <h1>PyPepper</h1>
 
+  <p>
+    <strong>Composable building blocks for Python microservices.</strong><br />
+    Build faster. Live more.
+  </p>
+
+  <p>
+    <a href="https://pypi.org/project/pypepper/"><img src="https://img.shields.io/pypi/v/pypepper?style=flat-square&logo=pypi&logoColor=white&label=PyPI" alt="PyPI" /></a>
+    <a href="https://jovijovi.github.io/pypepper/"><img src="https://img.shields.io/badge/docs-online-0A7EA4?style=flat-square" alt="Docs" /></a>
+    <a href="https://github.com/jovijovi/pypepper/actions"><img src="https://img.shields.io/github/actions/workflow/status/jovijovi/pypepper/test.yaml?branch=main&style=flat-square&label=CI" alt="CI" /></a>
+    <a href="https://codecov.io/gh/jovijovi/pypepper"><img src="https://img.shields.io/codecov/c/github/jovijovi/pypepper?style=flat-square&logo=codecov&logoColor=white" alt="Coverage" /></a>
+    <a href="https://www.python.org/"><img src="https://img.shields.io/badge/python-3.10%E2%80%933.14-3776AB?style=flat-square&logo=python&logoColor=white" alt="Python" /></a>
+    <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-2F2F2F?style=flat-square" alt="License" /></a>
+  </p>
 </div>
 
-# PyPepper
+<p align="center"><em>In memory of my father, who passed away in 2023 from COVID-19.</em></p>
 
-[![PyPI](https://img.shields.io/pypi/v/pypepper?label=\&logo=pypi\&logoColor=fff)](https://pypi.org/project/pypepper/)
-[![GitHub Actions](https://github.com/jovijovi/pypepper/workflows/Test/badge.svg)](https://github.com/jovijovi/pypepper)
-[![Coverage](https://img.shields.io/codecov/c/github/jovijovi/pypepper?label=\&logo=codecov\&logoColor=fff)](https://codecov.io/gh/jovijovi/pypepper)
+---
 
-> _In memory of my father, who passed away in 2023 from COVID-19._
+PyPepper packages the pieces you wire into services: **HTTP / SSE**, **FSM**, a **workflow scheduler**, signed **events**, thin **DB helpers**, and optional **OpenTelemetry** tracing — for Python `3.10`–`3.14`.
 
-PyPepper is a microservice toolkit.
+- Project: [https://github.com/jovijovi/pypepper](https://github.com/jovijovi/pypepper)
+- Docs: [https://jovijovi.github.io/pypepper/](https://jovijovi.github.io/pypepper/)
 
-<https://github.com/jovijovi/pypepper>
+## Documentation
 
-## :book: Documentation
+[Getting Started](https://jovijovi.github.io/pypepper/getting-started/) · [Architecture](https://jovijovi.github.io/pypepper/architecture/) · [Guides](https://jovijovi.github.io/pypepper/guides/common/) · [API Reference](https://jovijovi.github.io/pypepper/reference/)
 
-Online docs: <https://jovijovi.github.io/pypepper/>
+Source under [`docs/`](docs/index.md). Local preview: `make docs-serve`.
 
-Architecture overview, getting started, and domain guides. Local preview:
+## Domains
+
+| | Package | Role |
+|:--|:--|:--|
+| **Common** | `pypepper.common` | Config, logging, context, cache, crypto, utilities |
+| **Event** | `pypepper.event` | Signed domain events with JSON marshal |
+| **FSM** | `pypepper.fsm` | Event-triggered state machine with rollback |
+| **Scheduler** | `pypepper.scheduler` | `Job → Channel → Worker → Workflow` |
+| **Network** | `pypepper.network` | FastAPI HTTP server and SSE subsystem |
+| **Helper** | `pypepper.helper` | MySQL / PostgreSQL / MongoDB connectors |
+
+## Highlights
+
+| | |
+|:--|:--|
+| **Network** | FastAPI HTTP + SSE with API-key auth and rate limits → [guide](https://jovijovi.github.io/pypepper/guides/network-sse/) |
+| **FSM & events** | Rollback on handler failure; signed payloads → [guide](https://jovijovi.github.io/pypepper/guides/event-fsm/) |
+| **Scheduler** | Workflow job pipeline with retries → [guide](https://jovijovi.github.io/pypepper/guides/scheduler/) |
+| **Tracing** | Opt-in OpenTelemetry (console / local Jaeger) → [guide](https://jovijovi.github.io/pypepper/guides/tracing/) |
+| **Quality** | PEP 561 `py.typed` · ruff + mypy CI · coverage `≥ 90%` |
+| **Data** | Thin DB helpers → [guide](https://jovijovi.github.io/pypepper/guides/helper-db/) |
+
+## Quick start
+
+Requires Python `3.10`–`3.14` and [uv](https://github.com/astral-sh/uv) `≥ 0.10.7` (recommended).
 
 ```shell
-make docs-serve
+make build-prepare
 ```
 
-Source lives under [`docs/`](docs/index.md) (`mkdocs.yml`). Build with `make docs` (`mkdocs build --strict`).
+```shell
+export PYPEPPER_SSE_API_KEY=your-local-key
+python example/sse/app.py
+```
 
-## :checkered_flag: Features
+HTTP example:
 
-### ***common***
+```shell
+python example/server/app.py --config ./conf/app.config.yaml
+```
 
-Common packages.
+Full walkthrough: [Getting Started](https://jovijovi.github.io/pypepper/getting-started/).
 
-- `context`
-  - `common.context` A powerful chained context
-- `security`
-  - `common.security.crypto.elliptic.ecdsa` Sign/Verify message by ECDSA
-  - `common.security.crypto.digest` Get hash bytes/hex
-  - `common.security.crypto.salt` Generates a random salt of the specified size
-- `utils`
-  - `common.utils.random` A class for generating random values
-  - `common.utils.retry` Retry running the function by random interval, support lambda
-  - `common.utils.time` Get UTC/local datetime/timezone/timestamp, support sleep
-  - `common.utils.uuid` UUID(v4) generator
-- `cache`
-  - `common.cache` A thread safe TTL cache-set
-- `log`
-  - `common.log` A simple logger based on [loguru](https://github.com/Delgan/loguru)
-- `options`
-  - `common.options` An easy-to-use options
-- `system`
-  - `common.system` System signals handler
+<details>
+<summary><strong>Developer commands</strong></summary>
 
-### ***event***
+```shell
+make lint     # ruff + mypy
+make test     # check + pytest (coverage ≥ 90%)
+make docs     # mkdocs build --strict
+make docker   # local image
+make clean
+```
 
-An event package with payload, support sign/verify signature.
-
-### ***fsm***
-
-An out-of-box FSM with event trigger, support custom state.
-
-### ***helper***
-
-Database helper.
-
-- `helper.db.mongodb` MongoDB helper
-- `helper.db.mysql` MySQL helper
-- `helper.db.postgres` PostgreSQL helper
-
-### ***network***
-
-- `network.http` RESTFul API server based on [FastAPI](https://github.com/tiangolo/fastapi). 
-
-### ***scheduler***
-
-A Workflow-based job scheduler.
-
-### ***loader***
-
-Module loader.
-
-## :computer: Quick Guide
-
-- Development Environment
-  - python `3.10`,`3.11`,`3.12`,`3.13`,`3.14`
-  - uv >= `0.10.7`
-
-- Build code
-
-  Install all dependencies and compile code.
-
-  ```shell
-  make build
-  ```
-
-- Lint (ruff + mypy)
-
-  ```shell
-  make lint
-  ```
-
-- Test with coverage
-
-  ```shell
-  make test
-  ```
-
-  `make test` runs `make check` first (`make lint` + `scripts/check_mutable_class_attrs.py`).
-
-- Docs
-
-  ```shell
-  make docs
-  make docs-serve
-  ```
-
-- Build docker image
-
-  ```shell
-  make docker
-  ```
-
-- Clean
-
-  ```shell
-  make clean
-  ```
-
-- SSE example
-
-  Set a local API key (default config ships with empty `validKeys`):
-
-  ```shell
-  export PYPEPPER_SSE_API_KEY=your-local-key
-  python example/sse/app.py
-  ```
-
-## :bulb: Roadmap
-
-- [x] Documents
-- [x] Tracing
-- [x] Harden shared mutable state / FSM rollback / SSE auth defaults
-- [x] ruff + mypy CI gate
+</details>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -73,9 +73,16 @@ make docs-serve  # local preview
 
 Push to `main` deploys the site via GitHub Pages (`.github/workflows/docs.yml`).
 
+## Release
+
+Tag-triggered PyPI publishing: see [Release](guides/release.md).
+
+Summary: bump `version` in `pyproject.toml`, merge to `main`, then `git tag vX.Y.Z && git push origin vX.Y.Z` (tag must match the pyproject version). Configure PyPI Trusted Publisher once as described in that guide.
+
 ## Next steps
 
 - Read [Architecture](architecture.md) for module boundaries
 - Follow a domain guide under **Guides**
 - Browse the [API Reference](reference/index.md) for signatures and types
 - Optional: enable [Tracing](guides/tracing.md) (console and/or local Jaeger)
+- Maintainers: [Release](guides/release.md) to PyPI via Git tag

--- a/docs/guides/release.md
+++ b/docs/guides/release.md
@@ -1,0 +1,51 @@
+# Release
+
+Publish PyPepper to [PyPI](https://pypi.org/project/pypepper/) by pushing a Git tag. The package version in [`pyproject.toml`](https://github.com/jovijovi/pypepper/blob/main/pyproject.toml) is authoritative; the tag must match it.
+
+## One-time setup
+
+Do this once before the first tag-triggered release.
+
+### GitHub
+
+1. Open the repository **Settings → Environments**.
+2. Create an environment named `pypi` (optional: restrict who can deploy).
+
+### PyPI Trusted Publisher
+
+1. Sign in to [PyPI](https://pypi.org/) as a project owner/maintainer of `pypepper`.
+2. Open **Publishing** for the project (or pending publisher if the next version is new).
+3. Add a **Trusted Publisher** (GitHub):
+   - Owner: `jovijovi`
+   - Repository: `pypepper`
+   - Workflow name: `publish.yml`
+   - Environment name: `pypi`
+
+No long-lived API token is stored in the repository. A local `.pypirc` (gitignored) is only for manual uploads.
+
+## Release checklist
+
+1. Bump `version` in `pyproject.toml` (keep runtime pins in `requirements.txt` / `requirements-dev.txt` in sync when you change dependencies).
+2. Update [`CHANGELOG.md`](https://github.com/jovijovi/pypepper/blob/main/CHANGELOG.md) and merge to `main`.
+3. On the release commit (usually `main` tip):
+
+```shell
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+Example: if `pyproject.toml` has `version = "0.4.8"`, the tag must be `v0.4.8`.
+
+4. Watch **Actions → Publish to PyPI**. A mismatch between tag and `pyproject.toml` fails the job before upload.
+5. Confirm the version on [https://pypi.org/project/pypepper/](https://pypi.org/project/pypepper/).
+
+## Manual fallback
+
+Local publish (uses your machine credentials / `.pypirc`):
+
+```shell
+make publish-test   # TestPyPI
+make publish        # PyPI
+```
+
+Automated TestPyPI publishing from tags is not configured; use `make publish-test` when needed.

--- a/docs/guides/release.md
+++ b/docs/guides/release.md
@@ -34,7 +34,7 @@ git tag vX.Y.Z
 git push origin vX.Y.Z
 ```
 
-Example: if `pyproject.toml` has `version = "0.4.8"`, the tag must be `v0.4.8`.
+Example: if `pyproject.toml` has `version = "0.6.0"`, the tag must be `v0.6.0`.
 
 4. Watch **Actions → Publish to PyPI**. A mismatch between tag and `pyproject.toml` fails the job before upload.
 5. Confirm the version on [https://pypi.org/project/pypepper/](https://pypi.org/project/pypepper/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
       - Network and SSE: guides/network-sse.md
       - Tracing: guides/tracing.md
       - DB Helper: guides/helper-db.md
+      - Release: guides/release.md
   - API Reference:
       - reference/index.md
       - Common: reference/common.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pypepper"
-version = "0.4.7"
+version = "0.6.0"
 authors = [
     { name = "jovijovi", email = "mageyul@hotmail.com" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -634,6 +634,15 @@ wheels = [
 ]
 
 [[package]]
+name = "griffelib"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1036,6 +1045,20 @@ wheels = [
 ]
 
 [[package]]
+name = "mkdocs-autorefs"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/c0/f641843de3f612a6b48253f39244165acff36657a91cc903633d456ae1ac/mkdocs_autorefs-1.4.4.tar.gz", hash = "sha256:d54a284f27a7346b9c38f1f852177940c222da508e66edc816a0fa55fc6da197", size = 56588, upload-time = "2026-02-10T15:23:55.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/de/a3e710469772c6a89595fc52816da05c1e164b4c866a89e3cb82fb1b67c5/mkdocs_autorefs-1.4.4-py3-none-any.whl", hash = "sha256:834ef5408d827071ad1bc69e0f39704fa34c7fc05bc8e1c72b227dfdc5c76089", size = 25530, upload-time = "2026-02-10T15:23:53.817Z" },
+]
+
+[[package]]
 name = "mkdocs-get-deps"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1078,6 +1101,43 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocstrings"
+version = "1.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+    { name = "mkdocs-autorefs" },
+    { name = "pymdown-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/71/f85bdf13355073ae15a7375f09879375a830553552e58c1c4b7e0bbc5c8b/mkdocstrings-1.0.6.tar.gz", hash = "sha256:a0b8c2bdd29a6416c80d717aa369bbf7831946bd9f23c2a66db1b1dbe7693dbd", size = 100649, upload-time = "2026-07-11T19:38:05.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/5b/4c1902e8bdd5c4db63284e9d101dece4038d4025d6d88850ffe0a1578980/mkdocstrings-1.0.6-py3-none-any.whl", hash = "sha256:2703708697487d1b6d6d7b412e176fa436edf120c1bf81dc9e126b12d00893c7", size = 35787, upload-time = "2026-07-11T19:38:04.417Z" },
+]
+
+[package.optional-dependencies]
+python = [
+    { name = "mkdocstrings-python" },
+]
+
+[[package]]
+name = "mkdocstrings-python"
+version = "2.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffelib" },
+    { name = "mkdocs-autorefs" },
+    { name = "mkdocstrings" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/b6/e858701499d57eee8b3fd8e78168083956c6683ddbe727b46758b19e1119/mkdocstrings_python-2.0.5.tar.gz", hash = "sha256:3a4d92556ad39637e88af94a5374213af9a8e3040c3824ceaed04b486c017594", size = 199578, upload-time = "2026-06-19T10:41:08.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/fc/10ab7e80650a9c9e8f4f1105f8c8e73567f88ed0c06ada589ab81d38687c/mkdocstrings_python-2.0.5-py3-none-any.whl", hash = "sha256:30c837bbff016549f659fcba6539ac351303f0fd7e713c89a040611072236e9d", size = 104951, upload-time = "2026-06-19T10:41:07.378Z" },
 ]
 
 [[package]]
@@ -1679,7 +1739,7 @@ wheels = [
 
 [[package]]
 name = "pypepper"
-version = "0.4.7"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "arrow" },
@@ -1706,6 +1766,7 @@ dev = [
     { name = "coverage" },
     { name = "httpx" },
     { name = "mkdocs-material" },
+    { name = "mkdocstrings", extra = ["python"] },
     { name = "mypy" },
     { name = "packaging" },
     { name = "pip" },
@@ -1743,6 +1804,7 @@ dev = [
     { name = "coverage", specifier = "==7.15.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mkdocs-material", specifier = ">=9.6" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29" },
     { name = "mypy", specifier = "==2.3.0" },
     { name = "packaging", specifier = "==26.2" },
     { name = "pip", specifier = "==26.1.2" },


### PR DESCRIPTION
## Summary

- Problem: README was a long feature dump; releasing to PyPI still required manual local twine.
- Why it matters: clearer project landing page; maintainers can release by pushing a `v*` tag.
- What changed:
  - README refreshed (slogan, domains, highlights, quick start; single project/docs URL pair).
  - `.github/workflows/publish.yml`: on `v*` tags, verify tag == `pyproject.toml` version, build, publish via Trusted Publisher (OIDC).
  - Release guide + Getting Started / mkdocs / CHANGELOG notes.
- What did NOT change: no real PyPI upload in this PR; local `make publish` kept as fallback.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] common
- [ ] event
- [ ] fsm
- [ ] helper
- [ ] network
- [ ] scheduler
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Updated GitHub README landing content.
- Pushing `vX.Y.Z` (matching `pyproject.toml`) triggers PyPI publish after Trusted Publisher is configured.

## Security Impact (required)

- New permissions/capabilities? (`Yes` — workflow uses `id-token: write` for PyPI OIDC)
- Secrets/tokens handling changed? (`No` long-lived token in repo; Trusted Publisher)
- New/changed network calls? (`Yes` — CI uploads to PyPI on tags)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: OIDC scoped to Environment `pypi`; tag must match pyproject version before upload.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: n/a for docs; CI for publish path

### Steps

1. Review README and `docs/guides/release.md`
2. Confirm workflow YAML and local version-match check logic

### Expected

- Docs build; version mismatch fails before publish

### Actual

- Local docs build and version-check smoke done during implementation

## Evidence

- [x] Trace/log snippets — local version match/mismatch checks; `make docs` during implementation

## Human Verification (required)

- Verified scenarios: README content; publish workflow structure; docs nav for Release
- Edge cases checked: tag/pyproject mismatch fails
- What you did **not** verify: live PyPI upload (needs GitHub Environment `pypi` + PyPI Trusted Publisher configured, then a real tag)

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes` — one-time GitHub Environment `pypi` + PyPI Trusted Publisher)
- Migration needed? (`Yes` for maintainers before first tag release — see Release guide)

## Failure Recovery (if this breaks)

- How to disable/revert: revert PR or disable `publish.yml` / Environment
- Files/config to restore: `.github/workflows/publish.yml`, README, docs
- Known bad symptoms: publish job fails until Trusted Publisher is set up

## Risks and Mitigations

- Risk: accidental tag push publishes
  - Mitigation: Environment `pypi` protections; version must match pyproject; only `v*` tags
- Risk: first release fails without PyPI publisher config
  - Mitigation: documented in `docs/guides/release.md`