### PR TITLE
feat(scheduler): persist Job snapshots via pluggable store

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,20 +30,21 @@
 - Run `python scripts/check_mutable_class_attrs.py` (also via `make check` / `make test`) before opening a PR.
 
 ## Scheduler persistence semantics
-Job lifecycle is **at-least-once** with snapshots (`JobRecord`); workflows/executors are not serialized. Treat side effects as the source of truth when deciding rollback vs keep-terminal:
+Job snapshots (`JobRecord`) are metadata-only (workflows/executors are not serialized). Treat side effects as the source of truth when deciding rollback vs keep-terminal:
 
 | Stage | Persist failure | Required behavior |
 |-------|-----------------|-------------------|
 | Pre-execution (`INIT`/`SCHEDULE` in `dispatch`) | `save()` fails before enqueue | **Roll back** FSM/`Job.status` so `scheduled()` can retry |
-| Pre-execution (channel enqueue) | Bounded channel rejects send | **Roll back** FSM/`Job.status`, **delete** the Scheduled store row, raise (no ghost jobs) |
+| Pre-execution (channel enqueue) | Bounded channel rejects send | **Roll back** FSM/`Job.status`, best-effort **delete** Scheduled row, always re-raise `ChannelFullError` (no ghost jobs) |
 | Start (`RUN`) | Running snapshot fails | Do **not** run workflows; prefer persist `Failed`, else restore pre-`RUN` |
 | Terminal success (`COMPLETE`) | Work already finished | **Keep** Completed FSM; retry `job.save()` only — **never** re-run workflows because the terminal write failed |
 | Terminal failure (`FAIL`) | Work already failed | **Keep** Failed FSM; retry `job.save()` only |
 | `Job.save()` field updates | `put()` raises | Do **not** mutate in-memory `status`/`updated` until `put` succeeds |
 | `Job.to_record()` | — | Status comes from the **FSM** (authoritative view); may lead last durable `Job.status` after a failed terminal `save` |
-| SQL job store config | Missing `uri` and discrete fields | Raise `ValueError` with a clear message (not bare `assert`) |
+| SQL/Mongo job store config | Missing `uri` and discrete fields | Raise `ValueError` with a clear message (not bare `assert`) |
+| FSM transitions | Invalid event / transition | Raise; do not `save()` or run workflows |
 
-Prefer idempotent task executors when workers may retry after crashes (store can lag behind in-memory terminal state until `save` is retried).
+Schedule/enqueue failures are retry-safe. After work finishes (or fails), store lag means retry `save` only — not automatic redelivery. Prefer idempotent executors if callers manually re-dispatch in-flight jobs after a crash.
 
 ## Testing Guidelines
 - Test framework: `pytest` with `pytest-cov` (`pytest.ini` enforces `testpaths = tests` and `python_files = test_*.py`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Job snapshots (`JobRecord`) are metadata-only (workflows/executors are not seria
 | Stage | Persist failure | Required behavior |
 |-------|-----------------|-------------------|
 | Pre-execution (`INIT`/`SCHEDULE` in `dispatch`) | `save()` fails before enqueue | **Roll back** FSM/`Job.status` so `scheduled()` can retry |
-| Pre-execution (channel enqueue) | Bounded channel rejects send | **Roll back** FSM/`Job.status`, best-effort **delete** Scheduled row, always re-raise `ChannelFullError` (no ghost jobs) |
+| Pre-execution (channel enqueue) | Enqueue fails (channel full or other) | **Roll back** FSM/`Job.status`, best-effort **delete** Scheduled row, re-raise. Ghost Scheduled row may remain if delete fails. |
 | Start (`RUN`) | Running snapshot fails | Do **not** run workflows; prefer persist `Failed`, else restore pre-`RUN` |
 | Terminal success (`COMPLETE`) | Work already finished | **Keep** Completed FSM; retry `job.save()` only — **never** re-run workflows because the terminal write failed |
 | Terminal failure (`FAIL`) | Work already failed | **Keep** Failed FSM; retry `job.save()` only |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,22 @@
 - Global registries (`dispatcher`, `connection_manager`, `loader`, channel `manager`) must be **explicit singletons** (module-level instance and/or `__new__`), never accidental shared class dicts.
 - Run `python scripts/check_mutable_class_attrs.py` (also via `make check` / `make test`) before opening a PR.
 
+## Scheduler persistence semantics
+Job lifecycle is **at-least-once** with snapshots (`JobRecord`); workflows/executors are not serialized. Treat side effects as the source of truth when deciding rollback vs keep-terminal:
+
+| Stage | Persist failure | Required behavior |
+|-------|-----------------|-------------------|
+| Pre-execution (`INIT`/`SCHEDULE` in `dispatch`) | `save()` fails before enqueue | **Roll back** FSM/`Job.status` so `scheduled()` can retry |
+| Pre-execution (channel enqueue) | Bounded channel rejects send | **Roll back** FSM/`Job.status`, **delete** the Scheduled store row, raise (no ghost jobs) |
+| Start (`RUN`) | Running snapshot fails | Do **not** run workflows; prefer persist `Failed`, else restore pre-`RUN` |
+| Terminal success (`COMPLETE`) | Work already finished | **Keep** Completed FSM; retry `job.save()` only — **never** re-run workflows because the terminal write failed |
+| Terminal failure (`FAIL`) | Work already failed | **Keep** Failed FSM; retry `job.save()` only |
+| `Job.save()` field updates | `put()` raises | Do **not** mutate in-memory `status`/`updated` until `put` succeeds |
+| `Job.to_record()` | — | Status comes from the **FSM** (authoritative view); may lead last durable `Job.status` after a failed terminal `save` |
+| SQL job store config | Missing `uri` and discrete fields | Raise `ValueError` with a clear message (not bare `assert`) |
+
+Prefer idempotent task executors when workers may retry after crashes (store can lag behind in-memory terminal state until `save` is retried).
+
 ## Testing Guidelines
 - Test framework: `pytest` with `pytest-cov` (`pytest.ini` enforces `testpaths = tests` and `python_files = test_*.py`).
 - Place tests in the matching domain folder and name files/functions descriptively (`test_<unit>_<behavior>`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ Job snapshots (`JobRecord`) are metadata-only (workflows/executors are not seria
 
 | Stage | Persist failure | Required behavior |
 |-------|-----------------|-------------------|
-| Pre-execution (`INIT`/`SCHEDULE` in `dispatch`) | `save()` fails before enqueue | **Roll back** FSM/`Job.status` so `scheduled()` can retry |
-| Pre-execution (channel enqueue) | Enqueue fails before job lands on channel | **Roll back** FSM/`Job.status`, best-effort **delete** Scheduled row, re-raise. Ghost may remain if delete fails. After successful `send`, do **not** roll back. |
+| Pre-execution (`INIT`/`SCHEDULE` in `dispatch`) | `INIT`/`SCHEDULE`/`save()` fails before enqueue | **Roll back** FSM/`Job.status` so `scheduled()` can retry |
+| Pre-execution (channel enqueue) | Enqueue fails before job lands on channel | **Roll back** FSM/`Job.status`, best-effort **delete** Scheduled row, re-raise. Ghost may remain if delete fails. After successful `send`, do **not** roll back (exception still means the job may run). |
 | Start (`RUN`) | Running snapshot fails | Do **not** run workflows; prefer persist `Failed`, else restore pre-`RUN` |
 | Terminal success (`COMPLETE`) | Work already finished | **Keep** Completed FSM; retry `job.save()` only — **never** re-run workflows because the terminal write failed |
 | Terminal failure (`FAIL`) | Work already failed | **Keep** Failed FSM; retry `job.save()` only |
@@ -45,7 +45,7 @@ Job snapshots (`JobRecord`) are metadata-only (workflows/executors are not seria
 | SQL/Mongo job store config | Missing `uri` and discrete fields | Raise `ValueError` with a clear message (not bare `assert`) |
 | FSM transitions | Invalid event / transition | Raise; do not `save()` or run workflows |
 
-Schedule/enqueue failures are retry-safe. After work finishes (or fails), store lag means retry `save` only — not automatic redelivery. Prefer idempotent executors if callers manually re-dispatch in-flight jobs after a crash.
+Schedule and pre-channel enqueue failures are retry-safe. A raised error **after** successful channel `send` is a committed enqueue plus secondary failure — do **not** treat it as “nothing queued,” and do **not** blindly re-`scheduled()` the same job. After work finishes (or fails), store lag means retry `save` only — not automatic redelivery. Prefer idempotent executors if callers manually re-dispatch in-flight jobs after a crash.
 
 ## Testing Guidelines
 - Test framework: `pytest` with `pytest-cov` (`pytest.ini` enforces `testpaths = tests` and `python_files = test_*.py`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,12 +35,13 @@ Job snapshots (`JobRecord`) are metadata-only (workflows/executors are not seria
 | Stage | Persist failure | Required behavior |
 |-------|-----------------|-------------------|
 | Pre-execution (`INIT`/`SCHEDULE` in `dispatch`) | `save()` fails before enqueue | **Roll back** FSM/`Job.status` so `scheduled()` can retry |
-| Pre-execution (channel enqueue) | Enqueue fails (channel full or other) | **Roll back** FSM/`Job.status`, best-effort **delete** Scheduled row, re-raise. Ghost Scheduled row may remain if delete fails. |
+| Pre-execution (channel enqueue) | Enqueue fails before job lands on channel | **Roll back** FSM/`Job.status`, best-effort **delete** Scheduled row, re-raise. Ghost may remain if delete fails. After successful `send`, do **not** roll back. |
 | Start (`RUN`) | Running snapshot fails | Do **not** run workflows; prefer persist `Failed`, else restore pre-`RUN` |
 | Terminal success (`COMPLETE`) | Work already finished | **Keep** Completed FSM; retry `job.save()` only — **never** re-run workflows because the terminal write failed |
 | Terminal failure (`FAIL`) | Work already failed | **Keep** Failed FSM; retry `job.save()` only |
 | `Job.save()` field updates | `put()` raises | Do **not** mutate in-memory `status`/`updated` until `put` succeeds |
-| `Job.to_record()` | — | Status comes from the **FSM** (authoritative view); may lead last durable `Job.status` after a failed terminal `save` |
+| `Job.to_record()` | — | Status comes from the **FSM** (authoritative view); may lead last durable `Job.status` and in-memory `Job.status` after a failed terminal `save` |
+| `IJobStore.put` | Upsert by `id` | Must **not** overwrite existing ``created`` (memory/SQL/Mongo) |
 | SQL/Mongo job store config | Missing `uri` and discrete fields | Raise `ValueError` with a clear message (not bare `assert`) |
 | FSM transitions | Invalid event / transition | Raise; do not `save()` or run workflows |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Scheduler persist-failure semantics: roll back pre-execution schedule failures; keep terminal COMPLETE/FAIL when snapshot write fails (retry `save` only).
 - SQL job store raises `ValueError` for incomplete connection config instead of `AssertionError`.
 - Roll back and delete Scheduled snapshot when a bounded channel rejects enqueue; `Job.to_record()` uses FSM status.
+- Harden channel-full cleanup and FSM transition checks; preserve SQL `created` on upsert; validate Mongo config.
 
 ## 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@
 ### Fixed
 - Scheduler persist-failure semantics: roll back pre-execution schedule failures; keep terminal COMPLETE/FAIL when snapshot write fails (retry `save` only).
 - SQL job store raises `ValueError` for incomplete connection config instead of `AssertionError`.
-- Roll back and delete Scheduled snapshot when a bounded channel rejects enqueue; `Job.to_record()` uses FSM status.
-- Harden channel-full cleanup and FSM transition checks; preserve SQL `created` on upsert; validate Mongo config.
-- Roll back on any enqueue failure (not only channel-full); document best-effort delete may leave a ghost row.
+- Harden FSM transition checks; preserve `created` on upsert across memory/SQL/Mongo; validate Mongo config.
+- Roll back on enqueue failure (channel full or other) with best-effort delete (ghost possible); do not roll back after successful channel send.
+- `Job.to_record()` uses FSM status.
 
 ## 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - SQL job store raises `ValueError` for incomplete connection config instead of `AssertionError`.
 - Roll back and delete Scheduled snapshot when a bounded channel rejects enqueue; `Job.to_record()` uses FSM status.
 - Harden channel-full cleanup and FSM transition checks; preserve SQL `created` on upsert; validate Mongo config.
+- Roll back on any enqueue failure (not only channel-full); document best-effort delete may leave a ghost row.
 
 ## 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Added
+- Pluggable scheduler `Job.save` store with `memory` (default), `postgres`, `mysql`, and `mongodb` backends.
+
+### Fixed
+- Scheduler persist-failure semantics: roll back pre-execution schedule failures; keep terminal COMPLETE/FAIL when snapshot write fails (retry `save` only).
+- SQL job store raises `ValueError` for incomplete connection config instead of `AssertionError`.
+- Roll back and delete Scheduled snapshot when a bounded channel rejects enqueue; `Job.to_record()` uses FSM status.
+
 ## 0.6.0
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - SQL job store raises `ValueError` for incomplete connection config instead of `AssertionError`.
 - Harden FSM transition checks; preserve `created` on upsert across memory/SQL/Mongo; validate Mongo config.
 - Roll back on enqueue failure (channel full or other) with best-effort delete (ghost possible); do not roll back after successful channel send.
+- Document post-enqueue raise as committed enqueue (job may still run); Mongo disconnect hard-fails on non-benign errors.
 - `Job.to_record()` uses FSM status.
 
 ## 0.6.0

--- a/conf/app.config.yaml
+++ b/conf/app.config.yaml
@@ -73,6 +73,14 @@ tracing:
     enabled: false
     endpoint: http://127.0.0.1:4318
 
+# Scheduler job persistence (default memory). See docs/guides/scheduler.md
+scheduler:
+  jobStore:
+    backend: memory
+    # uri: postgresql+psycopg://postgres:example@localhost:5432/mock_pypepper
+    # uri: mysql+pymysql://root:example@localhost:3306/mock_pypepper?charset=utf8mb4
+    # uri: mongodb://test:test@localhost:27017/test
+
 # Custom config (Optional)
 custom:
   foo: "Something interesting"

--- a/devenv/ci.yaml
+++ b/devenv/ci.yaml
@@ -13,6 +13,7 @@ services:
       - ../.data/mysql_data:/var/lib/mysql
       - ./init/mysql/schema.sql:/docker-entrypoint-initdb.d/1_schema.sql
       - ./init/mysql/table.sql:/docker-entrypoint-initdb.d/2_table.sql
+      - ./init/mysql/scheduler_jobs.sql:/docker-entrypoint-initdb.d/3_scheduler_jobs.sql
     ports:
       - "3306:3306"
     healthcheck:

--- a/devenv/dev.yaml
+++ b/devenv/dev.yaml
@@ -13,6 +13,7 @@ services:
       - ../.data/mysql_data:/var/lib/mysql
       - ./init/mysql/schema.sql:/docker-entrypoint-initdb.d/1_schema.sql
       - ./init/mysql/table.sql:/docker-entrypoint-initdb.d/2_table.sql
+      - ./init/mysql/scheduler_jobs.sql:/docker-entrypoint-initdb.d/3_scheduler_jobs.sql
     ports:
       - "3306:3306"
     networks:

--- a/devenv/init/mysql/scheduler_jobs.sql
+++ b/devenv/init/mysql/scheduler_jobs.sql
@@ -1,0 +1,14 @@
+USE `mock_pypepper`;
+
+CREATE TABLE IF NOT EXISTS `scheduler_jobs` (
+  `id` VARCHAR(36) NOT NULL,
+  `category` VARCHAR(255) NULL,
+  `channel_id` VARCHAR(255) NOT NULL,
+  `status` VARCHAR(64) NOT NULL,
+  `created` VARCHAR(64) NOT NULL,
+  `updated` VARCHAR(64) NOT NULL,
+  `workflow_count` INT NOT NULL DEFAULT 0,
+  `version` INT NOT NULL DEFAULT 1,
+  PRIMARY KEY (`id`),
+  KEY `idx_scheduler_jobs_channel_id` (`channel_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/devenv/init/postgres/scheduler_jobs.sql
+++ b/devenv/init/postgres/scheduler_jobs.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS scheduler_jobs (
+  id VARCHAR(36) PRIMARY KEY,
+  category VARCHAR(255),
+  channel_id VARCHAR(255) NOT NULL,
+  status VARCHAR(64) NOT NULL,
+  created VARCHAR(64) NOT NULL,
+  updated VARCHAR(64) NOT NULL,
+  workflow_count INT NOT NULL DEFAULT 0,
+  version INT NOT NULL DEFAULT 1
+);
+
+CREATE INDEX IF NOT EXISTS idx_scheduler_jobs_channel_id ON scheduler_jobs (channel_id);

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@
 ARG PYTHON_VER=3.13
 ARG IMAGE_TAG=slim
 ARG BASE_IMAGE=python:${PYTHON_VER}-${IMAGE_TAG}
-ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.26
+ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.28
 
 FROM ${UV_IMAGE} AS uvbin
 

--- a/docs/guides/helper-db.md
+++ b/docs/guides/helper-db.md
@@ -67,4 +67,7 @@ mongodb.close()
 !!! tip
     Prefer environment-specific secrets outside the repo. The devenv passwords are for local/CI only.
 
+Scheduler job persistence builds on these connectors via
+[`configure_job_store`](scheduler.md#persistence) (`postgres` / `mysql` / `mongodb`).
+
 See also: [API Reference / DB Helper](../reference/helper.md).

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -122,11 +122,11 @@ Connections reuse [`helper.db`](helper-db.md) settings style (`uri` or discrete 
 ### Persist-failure rules
 
 - **Schedule** (`INIT`/`SCHEDULE` + `save` in `dispatch`): roll back FSM and `Job.status` so `scheduled()` can retry (no store delete needed if `save` never succeeded).
-- **Enqueue** (channel/processor setup or send rejected): roll back FSM/`Job.status` and best-effort delete the Scheduled store row. If delete fails, a Scheduled row may remain (ghost). After the job is successfully sent to the channel, do **not** roll back.
+- **Enqueue** (channel/processor setup or send rejected): roll back FSM/`Job.status` and best-effort delete the Scheduled store row. If delete fails, a Scheduled row may remain (ghost). After the job is successfully sent to the channel, do **not** roll back — a raised error then is a committed enqueue plus secondary failure (the job may still run); do not treat it as “nothing queued.”
 - **Start (`RUN`)**: if Running snapshot fails, do not run workflows; prefer persist `Failed`, else restore pre-RUN.
 - **After work** (COMPLETE/FAIL): keep the terminal FSM; retry `job.save()` only — do not re-run workflows because the snapshot write failed.
 - `Job.save()` updates in-memory `status`/`updated` only after the store `put` succeeds.
-- `Job.to_record()` reports FSM status (authoritative), which may lead durable store and in-memory `Job.status` when a terminal persist fails.
+- `Job.to_record()` reports FSM status (authoritative), which may lead last durable store status and in-memory `Job.status` when a terminal persist fails.
 - `IJobStore.put` upserts by `id` and must not overwrite an existing row's `created`.
 - Invalid FSM transitions raise; do not persist or run work after a failed transition.
 

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -73,8 +73,57 @@ Each `Job` owns an FSM from `build_scheduler_fsm()`:
 
     Prefer `retry_count` / `retry_delay` / `optional` until those semantics land.
 
-## Persistence stub
+## Persistence
 
-`Job.save()` currently logs only; there is no durable job store.
+`Job.save()` upserts a **metadata snapshot** (`JobRecord`) into the process-wide job store.
+Workflows / executors are **not** serialized.
+
+Default backend is **in-memory**. Switch to a database with `configure_job_store` (or YAML `scheduler.jobStore`):
+
+| Backend | Notes |
+|---------|--------|
+| `memory` | Default; process-local |
+| `postgres` | SQLAlchemy table `scheduler_jobs` |
+| `mysql` | Same table via PyMySQL |
+| `mongodb` | mongoengine collection `scheduler_jobs` |
+
+```python
+from pypepper.scheduler.job import Job
+from pypepper.scheduler.store import configure_job_store, get_job_store
+
+configure_job_store(
+    "postgres",
+    uri="postgresql+psycopg://postgres:example@localhost:5432/mock_pypepper",
+)
+
+job = Job(category="demo", channel_id="demo-channel")
+job.scheduled()  # INIT → SCHEDULE → save()
+
+saved = Job.get_saved(job.id)
+assert saved is not None
+assert saved.status == "Scheduled"
+
+# Or query the store directly
+assert get_job_store().get(job.id) is not None
+```
+
+YAML (optional):
+
+```yaml
+scheduler:
+  jobStore:
+    backend: postgres   # memory | postgres | mysql | mongodb
+    uri: postgresql+psycopg://postgres:example@localhost:5432/mock_pypepper
+```
+
+Connections reuse [`helper.db`](helper-db.md) settings style (`uri` or discrete host/user/password/db).
+`Worker` also calls `save()` after `RUN` / `COMPLETE` / `FAIL`.
+
+### Persist-failure rules
+
+- **Before work** (`dispatch` schedule / enqueue): roll back FSM (and remove Scheduled store row on channel-full) so `scheduled()` can retry.
+- **After work** (COMPLETE/FAIL): keep the terminal FSM; retry `job.save()` only — do not re-run workflows because the snapshot write failed.
+- `Job.save()` updates in-memory `status`/`updated` only after the store `put` succeeds.
+- `Job.to_record()` reports FSM status (authoritative), which may lead durable `Job.status` when a terminal persist fails.
 
 See also: [API Reference / Scheduler](../reference/scheduler.md).

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -121,9 +121,11 @@ Connections reuse [`helper.db`](helper-db.md) settings style (`uri` or discrete 
 
 ### Persist-failure rules
 
-- **Before work** (`dispatch` schedule / enqueue): roll back FSM (and remove Scheduled store row on channel-full) so `scheduled()` can retry.
+- **Before work** (`dispatch` schedule / enqueue): roll back FSM and `Job.status` (and best-effort delete Scheduled store row on channel-full) so `scheduled()` can retry.
+- **Start (`RUN`)**: if Running snapshot fails, do not run workflows; prefer persist `Failed`, else restore pre-RUN.
 - **After work** (COMPLETE/FAIL): keep the terminal FSM; retry `job.save()` only — do not re-run workflows because the snapshot write failed.
 - `Job.save()` updates in-memory `status`/`updated` only after the store `put` succeeds.
 - `Job.to_record()` reports FSM status (authoritative), which may lead durable `Job.status` when a terminal persist fails.
+- Invalid FSM transitions raise; do not persist or run work after a failed transition.
 
 See also: [API Reference / Scheduler](../reference/scheduler.md).

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -121,11 +121,13 @@ Connections reuse [`helper.db`](helper-db.md) settings style (`uri` or discrete 
 
 ### Persist-failure rules
 
-- **Before work** (`dispatch` schedule / enqueue): roll back FSM and `Job.status`, and best-effort delete the Scheduled store row, so `scheduled()` can retry. If delete fails, a Scheduled row may remain (ghost).
+- **Schedule** (`INIT`/`SCHEDULE` + `save` in `dispatch`): roll back FSM and `Job.status` so `scheduled()` can retry (no store delete needed if `save` never succeeded).
+- **Enqueue** (channel/processor setup or send rejected): roll back FSM/`Job.status` and best-effort delete the Scheduled store row. If delete fails, a Scheduled row may remain (ghost). After the job is successfully sent to the channel, do **not** roll back.
 - **Start (`RUN`)**: if Running snapshot fails, do not run workflows; prefer persist `Failed`, else restore pre-RUN.
 - **After work** (COMPLETE/FAIL): keep the terminal FSM; retry `job.save()` only — do not re-run workflows because the snapshot write failed.
 - `Job.save()` updates in-memory `status`/`updated` only after the store `put` succeeds.
-- `Job.to_record()` reports FSM status (authoritative), which may lead durable `Job.status` when a terminal persist fails.
+- `Job.to_record()` reports FSM status (authoritative), which may lead durable store and in-memory `Job.status` when a terminal persist fails.
+- `IJobStore.put` upserts by `id` and must not overwrite an existing row's `created`.
 - Invalid FSM transitions raise; do not persist or run work after a failed transition.
 
 See also: [API Reference / Scheduler](../reference/scheduler.md).

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -121,7 +121,7 @@ Connections reuse [`helper.db`](helper-db.md) settings style (`uri` or discrete 
 
 ### Persist-failure rules
 
-- **Before work** (`dispatch` schedule / enqueue): roll back FSM and `Job.status` (and best-effort delete Scheduled store row on channel-full) so `scheduled()` can retry.
+- **Before work** (`dispatch` schedule / enqueue): roll back FSM and `Job.status`, and best-effort delete the Scheduled store row, so `scheduled()` can retry. If delete fails, a Scheduled row may remain (ghost).
 - **Start (`RUN`)**: if Running snapshot fails, do not run workflows; prefer persist `Failed`, else restore pre-RUN.
 - **After work** (COMPLETE/FAIL): keep the terminal FSM; retry `job.save()` only — do not re-run workflows because the snapshot write failed.
 - `Job.save()` updates in-memory `status`/`updated` only after the store `put` succeeds.

--- a/docs/reference/scheduler.md
+++ b/docs/reference/scheduler.md
@@ -29,3 +29,7 @@ Workflow-based job pipeline. Narrative guide: [Scheduler](../guides/scheduler.md
 ## Events
 
 ::: pypepper.scheduler.events
+
+## Job store
+
+::: pypepper.scheduler.store

--- a/pypepper/common/config.py
+++ b/pypepper/common/config.py
@@ -90,6 +90,20 @@ class ConfTracing:
     otlp: ConfTracingOTLP
 
 
+class ConfSchedulerJobStore:
+    backend: str
+    uri: str | None
+    host: str | None
+    port: int | None
+    username: str | None
+    password: str | None
+    db: str | None
+
+
+class ConfScheduler:
+    jobStore: ConfSchedulerJobStore
+
+
 class YmlConfig:
     cluster: ConfCluster
     network: ConfNetwork
@@ -97,6 +111,7 @@ class YmlConfig:
     log: ConfLog
     sse: ConfSSE
     tracing: ConfTracing
+    scheduler: ConfScheduler
     custom: Any
 
 
@@ -140,8 +155,10 @@ class Config:
             log.set_colorize(self.get_yml_config().log.colorize)
 
         from pypepper.common.tracing import setup_from_config
+        from pypepper.scheduler.store import setup_from_config as setup_job_store_from_config
 
         setup_from_config(self.get_yml_config())
+        setup_job_store_from_config(self.get_yml_config())
 
     def get_yml_config(self) -> YmlConfig:
         return self._setting

--- a/pypepper/scheduler/job.py
+++ b/pypepper/scheduler/job.py
@@ -99,7 +99,7 @@ class Dispatcher:
         return self._new_processor(key)
 
     def dispatch(self, job: Job) -> None:
-        # Pre-execution: schedule/enqueue failure must roll back so retry can re-enter.
+        # Pre-channel schedule/enqueue failure must roll back so retry can re-enter.
         prev_state = job._fsm.current()
         prev_status = job.status
         try:
@@ -114,6 +114,7 @@ class Dispatcher:
         job.log()
 
         # Setup + enqueue: roll back only if the job never landed on the channel.
+        # After successful send, exceptions are committed-enqueue + secondary failure.
         enqueued = False
 
         def _mark_enqueued() -> None:
@@ -127,7 +128,7 @@ class Dispatcher:
         except Exception as enqueue_exc:
             if enqueued:
                 log.error(
-                    f"Job post-enqueue error (not rolled back): id={job.id}, "
+                    f"Job post-enqueue error (committed; job may still run): id={job.id}, "
                     f"channel_id={job.channel_id}, error={enqueue_exc}"
                 )
                 raise

--- a/pypepper/scheduler/job.py
+++ b/pypepper/scheduler/job.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from abc import ABCMeta, abstractmethod
-from collections.abc import MutableMapping
+from collections.abc import Callable, MutableMapping
 from threading import Lock
 
 from pypepper.common.context import Context
@@ -34,15 +34,23 @@ def _raise_if_transition_failed(resp_error: object) -> None:
 
 
 class Processor:
-    def run(self, job: Job, chan: Channel) -> None:
-        asyncio.run(self.async_run(job, chan))
+    def run(self, job: Job, chan: Channel, *, on_enqueued: Callable[[], None] | None = None) -> None:
+        asyncio.run(self.async_run(job, chan, on_enqueued=on_enqueued))
 
     @staticmethod
-    async def async_run(job: Job, chan: Channel) -> None:
+    async def async_run(
+        job: Job,
+        chan: Channel,
+        *,
+        on_enqueued: Callable[[], None] | None = None,
+    ) -> None:
         ok = await chan.send(job)
         if not ok:
             raise ChannelFullError(f"channel full: channel_id={job.channel_id}, job_id={job.id}")
-        print("[Processor] JobID=", job.id, "Channel Length=", chan.length())
+        # Job is on the channel: callers must not roll back schedule/store after this.
+        if on_enqueued is not None:
+            on_enqueued()
+        log.debug(f"Job enqueued: id={job.id}, channel_length={chan.length()}")
 
 
 class Dispatcher:
@@ -105,12 +113,24 @@ class Dispatcher:
 
         job.log()
 
-        chan = manager.available(job.channel_id)
-        processor = self._available_processor(job.channel_id)
+        # Setup + enqueue: roll back only if the job never landed on the channel.
+        enqueued = False
+
+        def _mark_enqueued() -> None:
+            nonlocal enqueued
+            enqueued = True
+
         try:
-            processor.run(job, chan)
+            chan = manager.available(job.channel_id)
+            processor = self._available_processor(job.channel_id)
+            processor.run(job, chan, on_enqueued=_mark_enqueued)
         except Exception as enqueue_exc:
-            # Any pre-execution enqueue failure: roll back so scheduled() can retry.
+            if enqueued:
+                log.error(
+                    f"Job post-enqueue error (not rolled back): id={job.id}, "
+                    f"channel_id={job.channel_id}, error={enqueue_exc}"
+                )
+                raise
             job.restore_lifecycle(prev_state, prev_status)
             try:
                 get_job_store().delete(job.id)

--- a/pypepper/scheduler/job.py
+++ b/pypepper/scheduler/job.py
@@ -11,6 +11,7 @@ from pypepper.common.context import Context
 from pypepper.common.log import log
 from pypepper.common.utils import uuid
 from pypepper.common.utils.time import get_utc_datetime
+from pypepper.event.interfaces import IEvent
 from pypepper.fsm.interfaces import IState
 from pypepper.scheduler import events
 from pypepper.scheduler.base import IBase
@@ -22,6 +23,14 @@ from pypepper.scheduler.workflow import Workflow
 
 class ChannelFullError(RuntimeError):
     """Bounded channel rejected an enqueue (pre-execution; safe to roll back)."""
+
+
+def _raise_if_transition_failed(resp_error: object) -> None:
+    if resp_error is None:
+        return
+    if isinstance(resp_error, BaseException):
+        raise resp_error
+    raise RuntimeError(str(resp_error))
 
 
 class Processor:
@@ -85,12 +94,13 @@ class Dispatcher:
         # Pre-execution: schedule/enqueue failure must roll back so retry can re-enter.
         prev_state = job._fsm.current()
         prev_status = job.status
-        job._fsm.on(events.INIT)
-        job._fsm.on(events.SCHEDULE)
         try:
+            job.apply_event(events.INIT)
+            job.apply_event(events.SCHEDULE)
             job.save()
-        except Exception:
+        except Exception as exc:
             job.restore_lifecycle(prev_state, prev_status)
+            log.error(f"Job schedule failed: id={job.id}, error={exc}")
             raise
 
         job.log()
@@ -101,7 +111,11 @@ class Dispatcher:
             processor.run(job, chan)
         except ChannelFullError:
             job.restore_lifecycle(prev_state, prev_status)
-            get_job_store().delete(job.id)
+            try:
+                get_job_store().delete(job.id)
+            except Exception as delete_exc:
+                log.error(f"Job channel-full cleanup delete failed: id={job.id}, error={delete_exc}")
+            log.error(f"Job enqueue failed (channel full): id={job.id}, channel_id={job.channel_id}")
             raise
 
 
@@ -148,9 +162,14 @@ class Job(IJob):
         return str(value)
 
     def restore_lifecycle(self, state: IState | None, status: str) -> None:
-        """Restore FSM current state and Job.status (pre-execution rollback only)."""
+        """Restore FSM/`status` after a failed lifecycle persist (schedule/enqueue or RUN-start)."""
         self._fsm._current = state
         self.status = status
+
+    def apply_event(self, event: IEvent) -> None:
+        """Apply an FSM event or raise if the transition is invalid."""
+        resp = self._fsm.on(event)
+        _raise_if_transition_failed(resp.error)
 
     def to_record(self) -> JobRecord:
         """Authoritative lifecycle snapshot from the FSM (may lead durable ``status``)."""

--- a/pypepper/scheduler/job.py
+++ b/pypepper/scheduler/job.py
@@ -10,10 +10,18 @@ from threading import Lock
 from pypepper.common.context import Context
 from pypepper.common.log import log
 from pypepper.common.utils import uuid
+from pypepper.common.utils.time import get_utc_datetime
+from pypepper.fsm.interfaces import IState
 from pypepper.scheduler import events
 from pypepper.scheduler.base import IBase
 from pypepper.scheduler.channel import Channel, manager
+from pypepper.scheduler.status import Status
+from pypepper.scheduler.store import JobRecord, get_job_store
 from pypepper.scheduler.workflow import Workflow
+
+
+class ChannelFullError(RuntimeError):
+    """Bounded channel rejected an enqueue (pre-execution; safe to roll back)."""
 
 
 class Processor:
@@ -22,7 +30,9 @@ class Processor:
 
     @staticmethod
     async def async_run(job: Job, chan: Channel) -> None:
-        await chan.send(job)
+        ok = await chan.send(job)
+        if not ok:
+            raise ChannelFullError(f"channel full: channel_id={job.channel_id}, job_id={job.id}")
         print("[Processor] JobID=", job.id, "Channel Length=", chan.length())
 
 
@@ -72,15 +82,27 @@ class Dispatcher:
         return self._new_processor(key)
 
     def dispatch(self, job: Job) -> None:
+        # Pre-execution: schedule/enqueue failure must roll back so retry can re-enter.
+        prev_state = job._fsm.current()
+        prev_status = job.status
         job._fsm.on(events.INIT)
         job._fsm.on(events.SCHEDULE)
+        try:
+            job.save()
+        except Exception:
+            job.restore_lifecycle(prev_state, prev_status)
+            raise
 
-        job.save()
         job.log()
 
         chan = manager.available(job.channel_id)
         processor = self._available_processor(job.channel_id)
-        processor.run(job, chan)
+        try:
+            processor.run(job, chan)
+        except ChannelFullError:
+            job.restore_lifecycle(prev_state, prev_status)
+            get_job_store().delete(job.id)
+            raise
 
 
 dispatcher = Dispatcher()
@@ -104,15 +126,67 @@ class IJob(IBase, metaclass=ABCMeta):
 
 class Job(IJob):
     def __init__(self, category: str | None = None, channel_id: str = "default") -> None:
+        now = get_utc_datetime()
         self.id = uuid.new_uuid()
         self.category: str | None = category
         self.channel_id = channel_id
         self.context = Context(context_id=uuid.new_uuid())
         self.workflows: list[Workflow] = []
         self._fsm = events.build_scheduler_fsm()
+        self.status: str = Status.UNKNOWN.value
+        self.created: str = now
+        self.updated: str = now
+        self.version: int = 1
+
+    def _current_status(self) -> str:
+        current = self._fsm.current()
+        if current is None:
+            return Status.UNKNOWN.value
+        value = current.value
+        if isinstance(value, Status):
+            return value.value
+        return str(value)
+
+    def restore_lifecycle(self, state: IState | None, status: str) -> None:
+        """Restore FSM current state and Job.status (pre-execution rollback only)."""
+        self._fsm._current = state
+        self.status = status
+
+    def to_record(self) -> JobRecord:
+        """Authoritative lifecycle snapshot from the FSM (may lead durable ``status``)."""
+        return JobRecord(
+            id=self.id,
+            category=self.category,
+            channel_id=self.channel_id,
+            status=self._current_status(),
+            created=self.created,
+            updated=self.updated,
+            workflow_count=len(self.workflows),
+            version=self.version,
+        )
 
     def save(self) -> None:
-        log.debug(f"Job saved: id={self.id}, channel_id={self.channel_id}")
+        status = self._current_status()
+        updated = get_utc_datetime()
+        record = JobRecord(
+            id=self.id,
+            category=self.category,
+            channel_id=self.channel_id,
+            status=status,
+            created=self.created,
+            updated=updated,
+            workflow_count=len(self.workflows),
+            version=self.version,
+        )
+        get_job_store().put(record)
+        # Mutate in-memory fields only after durable persist succeeds.
+        self.status = status
+        self.updated = updated
+        log.debug(f"Job saved: id={self.id}, channel_id={self.channel_id}, status={self.status}")
+
+    @staticmethod
+    def get_saved(job_id: str) -> JobRecord | None:
+        return get_job_store().get(job_id)
 
     def log(self) -> None:
         log.info(f"Job scheduled: id={self.id}, category={self.category}")

--- a/pypepper/scheduler/job.py
+++ b/pypepper/scheduler/job.py
@@ -109,13 +109,14 @@ class Dispatcher:
         processor = self._available_processor(job.channel_id)
         try:
             processor.run(job, chan)
-        except ChannelFullError:
+        except Exception as enqueue_exc:
+            # Any pre-execution enqueue failure: roll back so scheduled() can retry.
             job.restore_lifecycle(prev_state, prev_status)
             try:
                 get_job_store().delete(job.id)
             except Exception as delete_exc:
-                log.error(f"Job channel-full cleanup delete failed: id={job.id}, error={delete_exc}")
-            log.error(f"Job enqueue failed (channel full): id={job.id}, channel_id={job.channel_id}")
+                log.error(f"Job enqueue cleanup delete failed: id={job.id}, error={delete_exc}")
+            log.error(f"Job enqueue failed: id={job.id}, channel_id={job.channel_id}, error={enqueue_exc}")
             raise
 
 
@@ -162,7 +163,7 @@ class Job(IJob):
         return str(value)
 
     def restore_lifecycle(self, state: IState | None, status: str) -> None:
-        """Restore FSM/`status` after a failed lifecycle persist (schedule/enqueue or RUN-start)."""
+        """Restore FSM/`status` after schedule/enqueue failure or RUN-start persist failure."""
         self._fsm._current = state
         self.status = status
 

--- a/pypepper/scheduler/store/__init__.py
+++ b/pypepper/scheduler/store/__init__.py
@@ -1,0 +1,115 @@
+"""Pluggable job persistence (memory / postgres / mysql / mongodb)."""
+
+from __future__ import annotations
+
+from typing import Any, Literal, cast
+
+from pypepper.scheduler.store.interfaces import IJobStore, JobRecord
+from pypepper.scheduler.store.memory import InMemoryJobStore
+
+Backend = Literal["memory", "postgres", "mysql", "mongodb"]
+_VALID_BACKENDS: frozenset[str] = frozenset({"memory", "postgres", "mysql", "mongodb"})
+
+_job_store: IJobStore = InMemoryJobStore()
+
+
+def get_job_store() -> IJobStore:
+    return _job_store
+
+
+# Module-level handle used by Job.save (updated via set_job_store).
+job_store: IJobStore = _job_store
+
+
+def set_job_store(store: IJobStore) -> None:
+    """Replace the process-wide job store."""
+    global _job_store, job_store
+    _job_store = store
+    job_store = store
+
+
+def reset_job_store() -> None:
+    """Reset to a fresh in-memory store (tests)."""
+    set_job_store(InMemoryJobStore())
+
+
+def configure_job_store(backend: Backend = "memory", **kwargs: Any) -> IJobStore:
+    """
+    Build and install a job store.
+
+    Parameters
+    ----------
+    backend:
+        ``memory`` | ``postgres`` | ``mysql`` | ``mongodb``
+    **kwargs:
+        Connection options forwarded to the backend (e.g. ``uri``, ``host``,
+        ``port``, ``username``, ``password``, ``db``).
+    """
+    if backend == "memory":
+        store: IJobStore = InMemoryJobStore()
+    elif backend in ("postgres", "mysql"):
+        from pypepper.scheduler.store.sql import SqlJobStore
+
+        store = SqlJobStore(backend=backend, **kwargs)
+    elif backend == "mongodb":
+        from pypepper.scheduler.store.mongodb import MongoJobStore
+
+        store = MongoJobStore(**kwargs)
+    else:
+        raise ValueError(f"unsupported job store backend: {backend!r}")
+
+    set_job_store(store)
+    return store
+
+
+def setup_from_config(yml_config: Any | None = None) -> None:
+    """Configure job store from YAML ``scheduler.jobStore`` (optional)."""
+    if yml_config is None or not hasattr(yml_config, "scheduler"):
+        return
+    scheduler_cfg = yml_config.scheduler
+    if scheduler_cfg is None or not hasattr(scheduler_cfg, "jobStore"):
+        return
+    store_cfg = scheduler_cfg.jobStore
+    if store_cfg is None:
+        return
+
+    backend_raw = getattr(store_cfg, "backend", None) or "memory"
+    if backend_raw not in _VALID_BACKENDS:
+        raise ValueError(f"unsupported job store backend: {backend_raw!r}")
+    backend = cast(Backend, backend_raw)
+    # Avoid wiping an existing in-memory store when config still says memory.
+    if backend == "memory" and isinstance(get_job_store(), InMemoryJobStore):
+        return
+
+    kwargs: dict[str, Any] = {}
+    for key in (
+        "uri",
+        "host",
+        "port",
+        "username",
+        "password",
+        "db",
+        "sslmode",
+        "charset",
+        "auth_source",
+    ):
+        if hasattr(store_cfg, key):
+            value = getattr(store_cfg, key)
+            if value is not None:
+                kwargs[key] = value
+
+    configure_job_store(backend, **kwargs)
+
+
+__all__ = [
+    "Backend",
+    "IJobStore",
+    "InMemoryJobStore",
+    "JobRecord",
+    "configure_job_store",
+    "get_job_store",
+    "job_store",
+    "reset_job_store",
+    "set_job_store",
+    "setup_from_config",
+]

--- a/pypepper/scheduler/store/interfaces.py
+++ b/pypepper/scheduler/store/interfaces.py
@@ -1,0 +1,44 @@
+"""Job store interfaces and record model."""
+
+from __future__ import annotations
+
+from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class JobRecord:
+    """Serializable job snapshot (metadata only; no executors)."""
+
+    id: str
+    category: str | None
+    channel_id: str
+    status: str
+    created: str
+    updated: str
+    workflow_count: int = 0
+    version: int = 1
+
+
+class IJobStore(metaclass=ABCMeta):
+    """Pluggable persistence for JobRecord snapshots."""
+
+    @abstractmethod
+    def put(self, record: JobRecord) -> None:
+        pass
+
+    @abstractmethod
+    def get(self, job_id: str) -> JobRecord | None:
+        pass
+
+    @abstractmethod
+    def delete(self, job_id: str) -> None:
+        pass
+
+    @abstractmethod
+    def list(self, channel_id: str | None = None) -> list[JobRecord]:
+        pass
+
+    @abstractmethod
+    def clear(self) -> None:
+        pass

--- a/pypepper/scheduler/store/interfaces.py
+++ b/pypepper/scheduler/store/interfaces.py
@@ -25,6 +25,7 @@ class IJobStore(metaclass=ABCMeta):
 
     @abstractmethod
     def put(self, record: JobRecord) -> None:
+        """Upsert by ``id``. Must not overwrite an existing row's ``created``."""
         pass
 
     @abstractmethod

--- a/pypepper/scheduler/store/memory.py
+++ b/pypepper/scheduler/store/memory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from threading import Lock
 
 from pypepper.scheduler.store.interfaces import IJobStore, JobRecord
@@ -16,6 +17,9 @@ class InMemoryJobStore(IJobStore):
 
     def put(self, record: JobRecord) -> None:
         with self._lock:
+            existing = self._store.get(record.id)
+            if existing is not None:
+                record = replace(record, created=existing.created)
             self._store[record.id] = record
 
     def get(self, job_id: str) -> JobRecord | None:

--- a/pypepper/scheduler/store/memory.py
+++ b/pypepper/scheduler/store/memory.py
@@ -1,0 +1,38 @@
+"""In-memory JobStore (default / tests)."""
+
+from __future__ import annotations
+
+from threading import Lock
+
+from pypepper.scheduler.store.interfaces import IJobStore, JobRecord
+
+
+class InMemoryJobStore(IJobStore):
+    """Thread-safe dict-backed job store."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._store: dict[str, JobRecord] = {}
+
+    def put(self, record: JobRecord) -> None:
+        with self._lock:
+            self._store[record.id] = record
+
+    def get(self, job_id: str) -> JobRecord | None:
+        with self._lock:
+            return self._store.get(job_id)
+
+    def delete(self, job_id: str) -> None:
+        with self._lock:
+            self._store.pop(job_id, None)
+
+    def list(self, channel_id: str | None = None) -> list[JobRecord]:
+        with self._lock:
+            records = list(self._store.values())
+        if channel_id is None:
+            return records
+        return [r for r in records if r.channel_id == channel_id]
+
+    def clear(self) -> None:
+        with self._lock:
+            self._store.clear()

--- a/pypepper/scheduler/store/mongodb.py
+++ b/pypepper/scheduler/store/mongodb.py
@@ -1,0 +1,118 @@
+"""MongoDB / mongoengine JobStore."""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Any
+
+from mongoengine import Document, IntField, StringField, disconnect
+from mongoengine import connect as mongo_connect
+from mongoengine.context_managers import switch_db
+
+from pypepper.helper.db import mongodb as mongodb_helper
+from pypepper.scheduler.store.interfaces import IJobStore, JobRecord
+
+_DEFAULT_ALIAS = "pypepper_scheduler_jobs"
+
+
+class SchedulerJobDoc(Document):
+    """mongoengine document for job snapshots."""
+
+    meta = {
+        "collection": "scheduler_jobs",
+        "strict": False,
+        "db_alias": _DEFAULT_ALIAS,
+    }
+
+    id = StringField(primary_key=True)
+    category = StringField(null=True)
+    channel_id = StringField(required=True)
+    status = StringField(required=True)
+    created = StringField(required=True)
+    updated = StringField(required=True)
+    workflow_count = IntField(default=0)
+    version = IntField(default=1)
+
+
+def _doc_to_record(doc: SchedulerJobDoc) -> JobRecord:
+    return JobRecord(
+        id=str(doc.id),
+        category=doc.category,
+        channel_id=doc.channel_id,
+        status=doc.status,
+        created=doc.created,
+        updated=doc.updated,
+        workflow_count=int(doc.workflow_count or 0),
+        version=int(doc.version or 1),
+    )
+
+
+class MongoJobStore(IJobStore):
+    """Upsert job snapshots into MongoDB collection ``scheduler_jobs``."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        cfg = mongodb_helper.Config(
+            uri=kwargs.get("uri"),
+            username=kwargs.get("username"),
+            password=kwargs.get("password"),
+            host=kwargs.get("host"),
+            port=int(kwargs.get("port") or 27017),
+            db=kwargs.get("db"),
+            auth_source=kwargs.get("auth_source") or "admin",
+            uuid_representation=kwargs.get("uuid_representation") or "standard",
+        )
+        self._alias = kwargs.get("alias") or _DEFAULT_ALIAS
+        with contextlib.suppress(Exception):
+            disconnect(alias=self._alias)
+        if cfg.uri:
+            mongo_connect(
+                host=cfg.uri,
+                alias=self._alias,
+                uuidRepresentation="standard",
+            )
+        else:
+            mongo_connect(
+                username=cfg.username,
+                password=cfg.password,
+                host=cfg.host,
+                port=cfg.port,
+                db=cfg.db,
+                authentication_source=cfg.auth_source,
+                alias=self._alias,
+                uuidRepresentation="standard",
+            )
+
+    def put(self, record: JobRecord) -> None:
+        with switch_db(SchedulerJobDoc, self._alias):
+            doc = SchedulerJobDoc(
+                id=record.id,
+                category=record.category,
+                channel_id=record.channel_id,
+                status=record.status,
+                created=record.created,
+                updated=record.updated,
+                workflow_count=record.workflow_count,
+                version=record.version,
+            )
+            doc.save()
+
+    def get(self, job_id: str) -> JobRecord | None:
+        with switch_db(SchedulerJobDoc, self._alias):
+            doc = SchedulerJobDoc.objects(id=job_id).first()
+            if doc is None:
+                return None
+            return _doc_to_record(doc)
+
+    def delete(self, job_id: str) -> None:
+        with switch_db(SchedulerJobDoc, self._alias):
+            SchedulerJobDoc.objects(id=job_id).delete()
+
+    def list(self, channel_id: str | None = None) -> list[JobRecord]:
+        with switch_db(SchedulerJobDoc, self._alias):
+            qs = SchedulerJobDoc.objects
+            qs = qs(channel_id=channel_id) if channel_id is not None else qs()
+            return [_doc_to_record(doc) for doc in qs]
+
+    def clear(self) -> None:
+        with switch_db(SchedulerJobDoc, self._alias):
+            SchedulerJobDoc.objects.delete()

--- a/pypepper/scheduler/store/mongodb.py
+++ b/pypepper/scheduler/store/mongodb.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
 from typing import Any
 
 from mongoengine import Document, IntField, StringField, disconnect
@@ -62,8 +61,18 @@ class MongoJobStore(IJobStore):
             uuid_representation=kwargs.get("uuid_representation") or "standard",
         )
         self._alias = kwargs.get("alias") or _DEFAULT_ALIAS
-        with contextlib.suppress(Exception):
+        if not cfg.uri and not (cfg.username and cfg.password and cfg.host and cfg.db):
+            raise ValueError("mongodb job store requires uri=... or username, password, host, and db")
+        try:
             disconnect(alias=self._alias)
+        except Exception as exc:
+            log_msg = str(exc).lower()
+            if "not been created" in log_msg or "alias" in log_msg or "does not exist" in log_msg:
+                pass
+            else:
+                from pypepper.common.log import log
+
+                log.warn(f"MongoJobStore disconnect({self._alias}) failed: {exc}")
         if cfg.uri:
             mongo_connect(
                 host=cfg.uri,

--- a/pypepper/scheduler/store/mongodb.py
+++ b/pypepper/scheduler/store/mongodb.py
@@ -69,11 +69,17 @@ class MongoJobStore(IJobStore):
             from pypepper.common.log import log
 
             log_msg = str(exc).lower()
-            # Only treat "alias not registered" as benign; never match bare "alias".
-            if "not been created" in log_msg or "does not exist" in log_msg:
+            # Only treat missing-alias as benign; never match bare "alias" alone.
+            benign = (
+                "not been created" in log_msg
+                or "has not been defined" in log_msg
+                or ("does not exist" in log_msg and "alias" in log_msg)
+            )
+            if benign:
                 log.debug(f"MongoJobStore disconnect({self._alias}) skipped: {exc}")
             else:
-                log.warn(f"MongoJobStore disconnect({self._alias}) failed: {exc}")
+                log.error(f"MongoJobStore disconnect({self._alias}) failed: {exc}")
+                raise
         if cfg.uri:
             mongo_connect(
                 host=cfg.uri,

--- a/pypepper/scheduler/store/mongodb.py
+++ b/pypepper/scheduler/store/mongodb.py
@@ -66,12 +66,13 @@ class MongoJobStore(IJobStore):
         try:
             disconnect(alias=self._alias)
         except Exception as exc:
-            log_msg = str(exc).lower()
-            if "not been created" in log_msg or "alias" in log_msg or "does not exist" in log_msg:
-                pass
-            else:
-                from pypepper.common.log import log
+            from pypepper.common.log import log
 
+            log_msg = str(exc).lower()
+            # Only treat "alias not registered" as benign; never match bare "alias".
+            if "not been created" in log_msg or "does not exist" in log_msg:
+                log.debug(f"MongoJobStore disconnect({self._alias}) skipped: {exc}")
+            else:
                 log.warn(f"MongoJobStore disconnect({self._alias}) failed: {exc}")
         if cfg.uri:
             mongo_connect(
@@ -93,16 +94,26 @@ class MongoJobStore(IJobStore):
 
     def put(self, record: JobRecord) -> None:
         with switch_db(SchedulerJobDoc, self._alias):
-            doc = SchedulerJobDoc(
-                id=record.id,
-                category=record.category,
-                channel_id=record.channel_id,
-                status=record.status,
-                created=record.created,
-                updated=record.updated,
-                workflow_count=record.workflow_count,
-                version=record.version,
-            )
+            doc = SchedulerJobDoc.objects(id=record.id).first()
+            if doc is None:
+                SchedulerJobDoc(
+                    id=record.id,
+                    category=record.category,
+                    channel_id=record.channel_id,
+                    status=record.status,
+                    created=record.created,
+                    updated=record.updated,
+                    workflow_count=record.workflow_count,
+                    version=record.version,
+                ).save()
+                return
+            # Preserve original created (SQL upsert semantics).
+            doc.category = record.category
+            doc.channel_id = record.channel_id
+            doc.status = record.status
+            doc.updated = record.updated
+            doc.workflow_count = record.workflow_count
+            doc.version = record.version
             doc.save()
 
     def get(self, job_id: str) -> JobRecord | None:

--- a/pypepper/scheduler/store/sql.py
+++ b/pypepper/scheduler/store/sql.py
@@ -1,0 +1,145 @@
+"""SQLAlchemy JobStore for MySQL and PostgreSQL."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from sqlalchemy import Column, Integer, MetaData, String, Table, create_engine, select
+from sqlalchemy.dialects.mysql import insert as mysql_insert
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.engine import Engine
+
+from pypepper.helper.db import mysql, postgres
+from pypepper.scheduler.store.interfaces import IJobStore, JobRecord
+
+TABLE_NAME = "scheduler_jobs"
+
+_metadata = MetaData()
+
+scheduler_jobs = Table(
+    TABLE_NAME,
+    _metadata,
+    Column("id", String(36), primary_key=True),
+    Column("category", String(255), nullable=True),
+    Column("channel_id", String(255), nullable=False),
+    Column("status", String(64), nullable=False),
+    Column("created", String(64), nullable=False),
+    Column("updated", String(64), nullable=False),
+    Column("workflow_count", Integer, nullable=False, default=0),
+    Column("version", Integer, nullable=False, default=1),
+)
+
+
+def _engine_from_config(backend: Literal["postgres", "mysql"], **kwargs: Any) -> Engine:
+    if backend == "postgres":
+        cfg = postgres.Config(
+            uri=kwargs.get("uri"),
+            username=kwargs.get("username"),
+            password=kwargs.get("password"),
+            host=kwargs.get("host"),
+            port=int(kwargs.get("port") or 5432),
+            db=kwargs.get("db"),
+            sslmode=kwargs.get("sslmode"),
+        )
+        if cfg.uri:
+            return create_engine(cfg.uri)
+        if not (cfg.username and cfg.password and cfg.host and cfg.db):
+            raise ValueError("postgres job store requires uri=... or username, password, host, and db")
+        uri = f"postgresql+psycopg://{cfg.username}:{cfg.password}@{cfg.host}:{cfg.port}/{cfg.db}"
+        if cfg.sslmode:
+            uri = f"{uri}?sslmode={cfg.sslmode}"
+        return create_engine(uri)
+
+    mysql_cfg = mysql.Config(
+        uri=kwargs.get("uri"),
+        username=kwargs.get("username"),
+        password=kwargs.get("password"),
+        host=kwargs.get("host"),
+        port=int(kwargs.get("port") or 3306),
+        db=kwargs.get("db"),
+        charset=kwargs.get("charset") or "utf8mb4",
+    )
+    if mysql_cfg.uri:
+        return create_engine(mysql_cfg.uri)
+    if not (mysql_cfg.username and mysql_cfg.password and mysql_cfg.host and mysql_cfg.db):
+        raise ValueError("mysql job store requires uri=... or username, password, host, and db")
+    uri = (
+        f"mysql+pymysql://{mysql_cfg.username}:{mysql_cfg.password}"
+        f"@{mysql_cfg.host}:{mysql_cfg.port}/{mysql_cfg.db}?charset={mysql_cfg.charset}"
+    )
+    return create_engine(uri)
+
+
+def _row_to_record(row: Any) -> JobRecord:
+    return JobRecord(
+        id=row.id,
+        category=row.category,
+        channel_id=row.channel_id,
+        status=row.status,
+        created=row.created,
+        updated=row.updated,
+        workflow_count=int(row.workflow_count or 0),
+        version=int(row.version or 1),
+    )
+
+
+class SqlJobStore(IJobStore):
+    """Upsert job snapshots into ``scheduler_jobs`` (MySQL or PostgreSQL)."""
+
+    def __init__(self, backend: Literal["postgres", "mysql"], **kwargs: Any) -> None:
+        self._backend = backend
+        self._engine = _engine_from_config(backend, **kwargs)
+        _metadata.create_all(self._engine)
+
+    def put(self, record: JobRecord) -> None:
+        values = {
+            "id": record.id,
+            "category": record.category,
+            "channel_id": record.channel_id,
+            "status": record.status,
+            "created": record.created,
+            "updated": record.updated,
+            "workflow_count": record.workflow_count,
+            "version": record.version,
+        }
+        update_values = {
+            "category": record.category,
+            "channel_id": record.channel_id,
+            "status": record.status,
+            "created": record.created,
+            "updated": record.updated,
+            "workflow_count": record.workflow_count,
+            "version": record.version,
+        }
+        with self._engine.begin() as conn:
+            if self._backend == "postgres":
+                pg_stmt = pg_insert(scheduler_jobs).values(**values)
+                pg_stmt = pg_stmt.on_conflict_do_update(index_elements=["id"], set_=update_values)
+                conn.execute(pg_stmt)
+                return
+            mysql_stmt = mysql_insert(scheduler_jobs).values(**values)
+            mysql_stmt = mysql_stmt.on_duplicate_key_update(**update_values)
+            conn.execute(mysql_stmt)
+
+    def get(self, job_id: str) -> JobRecord | None:
+        with self._engine.connect() as conn:
+            row = conn.execute(select(scheduler_jobs).where(scheduler_jobs.c.id == job_id)).first()
+        if row is None:
+            return None
+        return _row_to_record(row)
+
+    def delete(self, job_id: str) -> None:
+        with self._engine.begin() as conn:
+            conn.execute(scheduler_jobs.delete().where(scheduler_jobs.c.id == job_id))
+
+    def list(self, channel_id: str | None = None) -> list[JobRecord]:
+        stmt = select(scheduler_jobs)
+        if channel_id is not None:
+            stmt = stmt.where(scheduler_jobs.c.channel_id == channel_id)
+        with self._engine.connect() as conn:
+            rows = conn.execute(stmt).fetchall()
+        return [_row_to_record(row) for row in rows]
+
+    def clear(self) -> None:
+        with self._engine.begin() as conn:
+            conn.execute(scheduler_jobs.delete())

--- a/pypepper/scheduler/store/sql.py
+++ b/pypepper/scheduler/store/sql.py
@@ -106,7 +106,6 @@ class SqlJobStore(IJobStore):
             "category": record.category,
             "channel_id": record.channel_id,
             "status": record.status,
-            "created": record.created,
             "updated": record.updated,
             "workflow_count": record.workflow_count,
             "version": record.version,

--- a/pypepper/scheduler/worker.py
+++ b/pypepper/scheduler/worker.py
@@ -20,7 +20,7 @@ def _transition_and_save_terminal(job: Job, event: IEvent) -> None:
     persistence fails. Callers should retry ``job.save()`` only — never re-run
     workflows solely because the terminal snapshot write failed.
     """
-    job._fsm.on(event)
+    job.apply_event(event)
     job.save()
 
 
@@ -45,13 +45,13 @@ class Worker:
     async def _process(self, job: Job) -> None:
         prev_state = job._fsm.current()
         prev_status = job.status
-        job._fsm.on(events.RUN)
+        job.apply_event(events.RUN)
         try:
             job.save()
         except Exception as save_exc:
             # Prefer persisting Failed; if that also fails, restore pre-RUN state.
             try:
-                job._fsm.on(events.FAIL)
+                job.apply_event(events.FAIL)
                 job.save()
             except Exception as fail_save_exc:
                 job.restore_lifecycle(prev_state, prev_status)
@@ -65,7 +65,7 @@ class Worker:
         try:
             workflows = getattr(job, "workflows", None) or []
             for workflow in workflows:
-                # Workflow.run is sync; offload to thread if needed later
+                # Workflow.run is sync; run it in a worker thread.
                 await asyncio.to_thread(workflow.run)
         except Exception as e:
             try:

--- a/pypepper/scheduler/worker.py
+++ b/pypepper/scheduler/worker.py
@@ -6,9 +6,22 @@ import asyncio
 from typing import cast
 
 from pypepper.common.log import log
+from pypepper.event.interfaces import IEvent
 from pypepper.scheduler import events
 from pypepper.scheduler.channel import Channel
 from pypepper.scheduler.job import Job
+
+
+def _transition_and_save_terminal(job: Job, event: IEvent) -> None:
+    """
+    Apply a terminal FSM event (COMPLETE / FAIL) then persist.
+
+    Work (or failure) has already happened: keep the terminal FSM state even if
+    persistence fails. Callers should retry ``job.save()`` only — never re-run
+    workflows solely because the terminal snapshot write failed.
+    """
+    job._fsm.on(event)
+    job.save()
 
 
 class Worker:
@@ -30,15 +43,48 @@ class Worker:
             await self.run_once()
 
     async def _process(self, job: Job) -> None:
+        prev_state = job._fsm.current()
+        prev_status = job.status
         job._fsm.on(events.RUN)
+        try:
+            job.save()
+        except Exception as save_exc:
+            # Prefer persisting Failed; if that also fails, restore pre-RUN state.
+            try:
+                job._fsm.on(events.FAIL)
+                job.save()
+            except Exception as fail_save_exc:
+                job.restore_lifecycle(prev_state, prev_status)
+                log.error(
+                    f"Job RUN persist failed: id={job.id}, error={save_exc}; FAIL persist also failed: {fail_save_exc}"
+                )
+                raise save_exc from fail_save_exc
+            log.error(f"Job RUN persist failed: id={job.id}, error={save_exc}")
+            raise
+
         try:
             workflows = getattr(job, "workflows", None) or []
             for workflow in workflows:
                 # Workflow.run is sync; offload to thread if needed later
                 await asyncio.to_thread(workflow.run)
-            job._fsm.on(events.COMPLETE)
-            log.info(f"Job completed: id={job.id}")
         except Exception as e:
-            job._fsm.on(events.FAIL)
+            try:
+                _transition_and_save_terminal(job, events.FAIL)
+            except Exception as save_exc:
+                log.error(
+                    f"Job failed: id={job.id}, error={e}; "
+                    f"terminal persist also failed (retry job.save only): {save_exc}"
+                )
+                raise e from save_exc
             log.error(f"Job failed: id={job.id}, error={e}")
             raise
+
+        try:
+            _transition_and_save_terminal(job, events.COMPLETE)
+        except Exception as save_exc:
+            log.error(
+                f"Job completed but terminal persist failed: id={job.id}; "
+                f"retry job.save only (do not re-run workflows): {save_exc}"
+            )
+            raise
+        log.info(f"Job completed: id={job.id}")

--- a/pypepper/scheduler/worker.py
+++ b/pypepper/scheduler/worker.py
@@ -59,7 +59,10 @@ class Worker:
                     f"Job RUN persist failed: id={job.id}, error={save_exc}; FAIL persist also failed: {fail_save_exc}"
                 )
                 raise save_exc from fail_save_exc
-            log.error(f"Job RUN persist failed: id={job.id}, error={save_exc}")
+            log.error(
+                f"Job RUN persist failed: id={job.id}, error={save_exc}; "
+                f"persisted Failed instead (do not re-run workflows)"
+            )
             raise
 
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from pypepper.loader import loader
 from pypepper.network.http.sse.connection import connection_manager
 from pypepper.network.http.sse.security import SSESecurityManager
 from pypepper.scheduler.channel import manager as channel_manager
+from pypepper.scheduler.store import reset_job_store
 
 
 @pytest.fixture(autouse=True)
@@ -22,6 +23,9 @@ def _reset_global_registries():
     # Loader registry
     loader._module_loader_mapper.clear()
 
+    # Scheduler job store
+    reset_job_store()
+
     # SSE rate-limit cache
     SSESecurityManager._rate_limit_cache = Cache(maxsize=1000, ttl=60)
 
@@ -30,6 +34,8 @@ def _reset_global_registries():
     yield
 
     tracing_shutdown()
+
+    reset_job_store()
 
     with connection_manager._lock:
         connection_manager._connections.clear()

--- a/tests/scheduler/test_job_store_db.py
+++ b/tests/scheduler/test_job_store_db.py
@@ -47,7 +47,7 @@ def _crud_roundtrip(backend: str, uri: str) -> None:
         category="demo2",
         channel_id=record.channel_id,
         status=Status.IN_PROGRESS.value,
-        created="t0",
+        created="should-not-overwrite",
         updated="t1",
         workflow_count=2,
         version=2,
@@ -58,6 +58,10 @@ def _crud_roundtrip(backend: str, uri: str) -> None:
     assert got.category == "demo2"
     assert got.status == Status.IN_PROGRESS.value
     assert got.version == 2
+    if backend in ("postgres", "mysql"):
+        assert got.created == "t0"
+    else:
+        assert got.created == "should-not-overwrite"
 
     store.delete(record.id)
     assert store.get(record.id) is None

--- a/tests/scheduler/test_job_store_db.py
+++ b/tests/scheduler/test_job_store_db.py
@@ -58,10 +58,7 @@ def _crud_roundtrip(backend: str, uri: str) -> None:
     assert got.category == "demo2"
     assert got.status == Status.IN_PROGRESS.value
     assert got.version == 2
-    if backend in ("postgres", "mysql"):
-        assert got.created == "t0"
-    else:
-        assert got.created == "should-not-overwrite"
+    assert got.created == "t0"
 
     store.delete(record.id)
     assert store.get(record.id) is None

--- a/tests/scheduler/test_job_store_db.py
+++ b/tests/scheduler/test_job_store_db.py
@@ -1,0 +1,147 @@
+"""Integration tests for DB-backed job stores (requires devenv)."""
+
+from __future__ import annotations
+
+import pytest
+
+from pypepper.scheduler import events
+from pypepper.scheduler.channel import Channel
+from pypepper.scheduler.executor import CallableExecutor
+from pypepper.scheduler.job import Job
+from pypepper.scheduler.status import Status
+from pypepper.scheduler.store import JobRecord, configure_job_store, get_job_store, reset_job_store
+from pypepper.scheduler.task import Task
+from pypepper.scheduler.worker import Worker
+from pypepper.scheduler.workflow import Workflow
+
+POSTGRES_URI = "postgresql+psycopg://postgres:example@localhost:5432/mock_pypepper"
+MYSQL_URI = "mysql+pymysql://root:example@localhost:3306/mock_pypepper?charset=utf8mb4"
+MONGO_URI = "mongodb://test:test@localhost:27017/test"
+
+
+@pytest.fixture(autouse=True)
+def _reset_store():
+    yield
+    reset_job_store()
+
+
+def _crud_roundtrip(backend: str, uri: str) -> None:
+    store = configure_job_store(backend, uri=uri)
+    record = JobRecord(
+        id=f"db-{backend}-1",
+        category="demo",
+        channel_id=f"ch-{backend}",
+        status=Status.SCHEDULED.value,
+        created="t0",
+        updated="t0",
+        workflow_count=1,
+        version=1,
+    )
+    store.clear()
+    store.put(record)
+    assert store.get(record.id) == record
+    assert store.list(channel_id=record.channel_id) == [record]
+
+    updated = JobRecord(
+        id=record.id,
+        category="demo2",
+        channel_id=record.channel_id,
+        status=Status.IN_PROGRESS.value,
+        created="t0",
+        updated="t1",
+        workflow_count=2,
+        version=2,
+    )
+    store.put(updated)
+    got = store.get(record.id)
+    assert got is not None
+    assert got.category == "demo2"
+    assert got.status == Status.IN_PROGRESS.value
+    assert got.version == 2
+
+    store.delete(record.id)
+    assert store.get(record.id) is None
+
+
+def test_postgres_crud():
+    _crud_roundtrip("postgres", POSTGRES_URI)
+
+
+def test_mysql_crud():
+    _crud_roundtrip("mysql", MYSQL_URI)
+
+
+def test_mongodb_crud():
+    _crud_roundtrip("mongodb", MONGO_URI)
+
+
+@pytest.mark.asyncio
+async def test_postgres_worker_lifecycle():
+    configure_job_store("postgres", uri=POSTGRES_URI)
+    get_job_store().clear()
+
+    def work(task, context):
+        return "ok"
+
+    workflow = Workflow()
+    workflow.add_task(
+        Task(
+            channel_id="ch",
+            dag_id="dag",
+            fingerprint="fp",
+            name="step1",
+            category="c",
+            description="",
+            tags=[],
+            executor=CallableExecutor(work),
+        )
+    )
+    job = Job(category="pg", channel_id="pg-lifecycle")
+    job.workflows = [workflow]
+    assert job._fsm.on(events.INIT).error is None
+    assert job._fsm.on(events.SCHEDULE).error is None
+    job.save()
+    assert Job.get_saved(job.id) is not None
+    assert Job.get_saved(job.id).status == Status.SCHEDULED.value
+
+    chan = Channel()
+    await chan.send(job)
+    await Worker(chan).run_once()
+    saved = Job.get_saved(job.id)
+    assert saved is not None
+    assert saved.status == Status.COMPLETED.value
+
+
+@pytest.mark.asyncio
+async def test_mongodb_worker_lifecycle():
+    configure_job_store("mongodb", uri=MONGO_URI)
+    get_job_store().clear()
+
+    def work(task, context):
+        return "ok"
+
+    workflow = Workflow()
+    workflow.add_task(
+        Task(
+            channel_id="ch",
+            dag_id="dag",
+            fingerprint="fp",
+            name="step1",
+            category="c",
+            description="",
+            tags=[],
+            executor=CallableExecutor(work),
+        )
+    )
+    job = Job(category="mongo", channel_id="mongo-lifecycle")
+    job.workflows = [workflow]
+    assert job._fsm.on(events.INIT).error is None
+    assert job._fsm.on(events.SCHEDULE).error is None
+    job.save()
+
+    chan = Channel()
+    await chan.send(job)
+    await Worker(chan).run_once()
+    saved = Job.get_saved(job.id)
+    assert saved is not None
+    assert saved.status == Status.COMPLETED.value

--- a/tests/scheduler/test_job_store_memory.py
+++ b/tests/scheduler/test_job_store_memory.py
@@ -1,0 +1,367 @@
+"""Unit tests for in-memory job store and Job.save lifecycle."""
+
+from __future__ import annotations
+
+import pytest
+from pypepper.scheduler import events
+from pypepper.scheduler.channel import Channel
+from pypepper.scheduler.executor import CallableExecutor
+from pypepper.scheduler.job import Job
+from pypepper.scheduler.status import Status
+from pypepper.scheduler.store import (
+    JobRecord,
+    configure_job_store,
+    get_job_store,
+    reset_job_store,
+    set_job_store,
+)
+from pypepper.scheduler.store.memory import InMemoryJobStore
+from pypepper.scheduler.task import Task
+from pypepper.scheduler.worker import Worker
+from pypepper.scheduler.workflow import Workflow
+
+
+@pytest.fixture(autouse=True)
+def _fresh_job_store():
+    reset_job_store()
+    yield
+    reset_job_store()
+
+
+def test_memory_put_get_list_delete():
+    store = get_job_store()
+    record = JobRecord(
+        id="job-1",
+        category="demo",
+        channel_id="ch-a",
+        status=Status.SCHEDULED.value,
+        created="t0",
+        updated="t1",
+        workflow_count=2,
+        version=1,
+    )
+    store.put(record)
+    assert store.get("job-1") == record
+    assert store.list(channel_id="ch-a") == [record]
+    assert store.list(channel_id="other") == []
+    store.delete("job-1")
+    assert store.get("job-1") is None
+
+
+def test_memory_put_upserts():
+    store = get_job_store()
+    store.put(
+        JobRecord(
+            id="job-1",
+            category="a",
+            channel_id="ch",
+            status=Status.SCHEDULED.value,
+            created="t0",
+            updated="t0",
+        )
+    )
+    store.put(
+        JobRecord(
+            id="job-1",
+            category="b",
+            channel_id="ch",
+            status=Status.COMPLETED.value,
+            created="t0",
+            updated="t1",
+        )
+    )
+    got = store.get("job-1")
+    assert got is not None
+    assert got.category == "b"
+    assert got.status == Status.COMPLETED.value
+
+
+def test_scheduled_persists_scheduled_status():
+    job = Job(category="Foo", channel_id="mem-sched")
+    job.scheduled()
+    saved = Job.get_saved(job.id)
+    assert saved is not None
+    assert saved.status == Status.SCHEDULED.value
+    assert saved.channel_id == "mem-sched"
+    assert saved.category == "Foo"
+
+
+@pytest.mark.asyncio
+async def test_worker_persists_completed_status():
+    def work(task, context):
+        return "ok"
+
+    workflow = Workflow()
+    workflow.add_task(
+        Task(
+            channel_id="ch",
+            dag_id="dag",
+            fingerprint="fp",
+            name="step1",
+            category="c",
+            description="",
+            tags=[],
+            executor=CallableExecutor(work),
+        )
+    )
+    job = Job(category="test", channel_id="mem-worker-ok")
+    job.workflows = [workflow]
+    assert job._fsm.on(events.INIT).error is None
+    assert job._fsm.on(events.SCHEDULE).error is None
+    job.save()
+
+    chan = Channel()
+    await chan.send(job)
+    await Worker(chan).run_once()
+
+    saved = Job.get_saved(job.id)
+    assert saved is not None
+    assert saved.status == Status.COMPLETED.value
+
+
+@pytest.mark.asyncio
+async def test_worker_persists_failed_status():
+    def boom(task, context):
+        raise RuntimeError("boom")
+
+    workflow = Workflow()
+    workflow.add_task(
+        Task(
+            channel_id="ch",
+            dag_id="dag",
+            fingerprint="fp",
+            name="step1",
+            category="c",
+            description="",
+            tags=[],
+            executor=CallableExecutor(boom),
+            retry_count=0,
+        )
+    )
+    job = Job(category="test", channel_id="mem-worker-fail")
+    job.workflows = [workflow]
+    assert job._fsm.on(events.INIT).error is None
+    assert job._fsm.on(events.SCHEDULE).error is None
+    job.save()
+
+    chan = Channel()
+    await chan.send(job)
+    with pytest.raises(RuntimeError, match="boom"):
+        await Worker(chan).run_once()
+
+    saved = Job.get_saved(job.id)
+    assert saved is not None
+    assert saved.status == Status.FAILED.value
+
+
+def test_set_and_configure_job_store():
+    custom = InMemoryJobStore()
+    set_job_store(custom)
+    assert get_job_store() is custom
+
+    configured = configure_job_store("memory")
+    assert isinstance(configured, InMemoryJobStore)
+    assert get_job_store() is configured
+
+
+class _FailingStore(InMemoryJobStore):
+    def put(self, record: JobRecord) -> None:
+        if record.status in (Status.COMPLETED.value, Status.FAILED.value):
+            raise RuntimeError("persist-failed")
+        super().put(record)
+
+
+class _FailOnInProgressStore(InMemoryJobStore):
+    def put(self, record: JobRecord) -> None:
+        if record.status == Status.IN_PROGRESS.value:
+            raise RuntimeError("run-persist-failed")
+        super().put(record)
+
+
+class _AlwaysFailStore(InMemoryJobStore):
+    def put(self, record: JobRecord) -> None:
+        raise RuntimeError("always-fail")
+
+
+def _job_with_workflow(executor):
+    workflow = Workflow()
+    workflow.add_task(
+        Task(
+            channel_id="ch",
+            dag_id="dag",
+            fingerprint="fp",
+            name="step1",
+            category="c",
+            description="",
+            tags=[],
+            executor=CallableExecutor(executor),
+            retry_count=0,
+        )
+    )
+    job = Job(category="test", channel_id="mem-save-err")
+    job.workflows = [workflow]
+    assert job._fsm.on(events.INIT).error is None
+    assert job._fsm.on(events.SCHEDULE).error is None
+    return job
+
+
+@pytest.mark.asyncio
+async def test_run_save_failure_marks_job_failed():
+    set_job_store(_FailOnInProgressStore())
+    executed = []
+
+    def work(task, context):
+        executed.append(task.name)
+        return "ok"
+
+    job = _job_with_workflow(work)
+    job.save()
+    chan = Channel()
+    await chan.send(job)
+
+    with pytest.raises(RuntimeError, match="run-persist-failed"):
+        await Worker(chan).run_once()
+
+    assert executed == []
+    assert job._fsm.current().value == Status.FAILED
+    saved = Job.get_saved(job.id)
+    assert saved is not None
+    assert saved.status == Status.FAILED.value
+
+
+@pytest.mark.asyncio
+async def test_complete_save_failure_keeps_completed_fsm():
+    set_job_store(_FailingStore())
+
+    def work(task, context):
+        return "ok"
+
+    job = _job_with_workflow(work)
+    job.save()
+    chan = Channel()
+    await chan.send(job)
+
+    with pytest.raises(RuntimeError, match="persist-failed"):
+        await Worker(chan).run_once()
+
+    # Work finished: keep Completed; retry job.save() only (store may still be InProgress).
+    assert job._fsm.current().value == Status.COMPLETED
+    saved = Job.get_saved(job.id)
+    assert saved is not None
+    assert saved.status == Status.IN_PROGRESS.value
+
+
+@pytest.mark.asyncio
+async def test_fail_path_save_failure_keeps_failed_fsm():
+    set_job_store(_FailingStore())
+
+    def boom(task, context):
+        raise RuntimeError("boom")
+
+    job = _job_with_workflow(boom)
+    job.save()
+    chan = Channel()
+    await chan.send(job)
+
+    with pytest.raises(RuntimeError, match="boom") as exc_info:
+        await Worker(chan).run_once()
+
+    assert "persist-failed" not in str(exc_info.value)
+    # Terminal failure kept; retry job.save() only.
+    assert job._fsm.current().value == Status.FAILED
+    saved = Job.get_saved(job.id)
+    assert saved is not None
+    assert saved.status == Status.IN_PROGRESS.value
+
+
+def test_dispatch_save_failure_rolls_back_for_retry():
+    set_job_store(_AlwaysFailStore())
+    job = Job(category="x", channel_id="dispatch-rollback")
+
+    with pytest.raises(RuntimeError, match="always-fail"):
+        job.scheduled()
+
+    assert job._fsm.current().value == Status.UNKNOWN
+    assert Job.get_saved(job.id) is None
+
+    reset_job_store()
+    job.scheduled()
+    assert Job.get_saved(job.id) is not None
+    assert Job.get_saved(job.id).status == Status.SCHEDULED.value
+
+
+def test_sql_missing_connection_raises_value_error():
+    from pypepper.scheduler.store.sql import SqlJobStore
+
+    with pytest.raises(ValueError, match="postgres job store requires"):
+        SqlJobStore(backend="postgres", host="localhost")
+    with pytest.raises(ValueError, match="mysql job store requires"):
+        SqlJobStore(backend="mysql", host="localhost")
+
+
+def test_setup_from_config_memory_preserves_existing_store():
+    from types import SimpleNamespace
+
+    from pypepper.scheduler.store import setup_from_config
+
+    store = get_job_store()
+    store.put(
+        JobRecord(
+            id="keep-me",
+            category="c",
+            channel_id="ch",
+            status=Status.SCHEDULED.value,
+            created="t0",
+            updated="t0",
+        )
+    )
+    setup_from_config(SimpleNamespace(scheduler=SimpleNamespace(jobStore=SimpleNamespace(backend="memory"))))
+    assert get_job_store() is store
+    assert get_job_store().get("keep-me") is not None
+
+
+def test_save_failure_does_not_mutate_job_fields():
+    set_job_store(_AlwaysFailStore())
+    job = Job(category="x", channel_id="ch")
+    assert job._fsm.on(events.INIT).error is None
+    assert job._fsm.on(events.SCHEDULE).error is None
+    before_status = job.status
+    before_updated = job.updated
+
+    with pytest.raises(RuntimeError, match="always-fail"):
+        job.save()
+
+    assert job.status == before_status
+    assert job.updated == before_updated
+    assert Job.get_saved(job.id) is None
+
+
+def test_to_record_uses_fsm_status():
+    job = Job(category="x", channel_id="ch")
+    assert job.status == Status.UNKNOWN.value
+    assert job._fsm.on(events.INIT).error is None
+    assert job._fsm.on(events.SCHEDULE).error is None
+    # FSM advanced; durable Job.status not updated until save succeeds.
+    assert job.status == Status.UNKNOWN.value
+    assert job.to_record().status == Status.SCHEDULED.value
+
+
+def test_channel_full_rolls_back_and_deletes_scheduled():
+    import asyncio
+
+    from pypepper.scheduler.channel import manager
+    from pypepper.scheduler.job import ChannelFullError
+
+    channel_id = "bounded-full"
+    bounded = Channel(maxsize=1)
+    assert asyncio.run(bounded.send("occupier")) is True
+    manager.put(channel_id, bounded)
+    try:
+        job = Job(category="x", channel_id=channel_id)
+        with pytest.raises(ChannelFullError, match="channel full"):
+            job.scheduled()
+
+        assert job._fsm.current().value == Status.UNKNOWN
+        assert Job.get_saved(job.id) is None
+    finally:
+        manager.remove(channel_id)

--- a/tests/scheduler/test_job_store_memory.py
+++ b/tests/scheduler/test_job_store_memory.py
@@ -506,6 +506,38 @@ def test_channel_full_delete_failure_still_raises_channel_full():
         manager.remove(channel_id)
 
 
+def test_channel_full_ghost_then_retry_upserts():
+    """Ghost Scheduled row after failed cleanup must not block a later successful schedule."""
+    import asyncio
+
+    from pypepper.scheduler.channel import manager
+    from pypepper.scheduler.job import ChannelFullError
+
+    set_job_store(_FailDeleteStore())
+    channel_id = "bounded-ghost-retry"
+    bounded = Channel(maxsize=1)
+    assert asyncio.run(bounded.send("occupier")) is True
+    manager.put(channel_id, bounded)
+    try:
+        job = Job(category="x", channel_id=channel_id)
+        with pytest.raises(ChannelFullError):
+            job.scheduled()
+        ghost = Job.get_saved(job.id)
+        assert ghost is not None
+        ghost_created = ghost.created
+
+        assert asyncio.run(bounded.receive()) == "occupier"
+        job.scheduled()
+        saved = Job.get_saved(job.id)
+        assert saved is not None
+        assert saved.status == Status.SCHEDULED.value
+        assert saved.created == ghost_created
+        assert job._fsm.current().value == Status.SCHEDULED
+        assert job.status == Status.SCHEDULED.value
+    finally:
+        manager.remove(channel_id)
+
+
 def test_enqueue_failure_rolls_back_for_any_error(monkeypatch):
     from pypepper.scheduler.job import Processor
 
@@ -523,6 +555,9 @@ def test_enqueue_failure_rolls_back_for_any_error(monkeypatch):
 
 
 def test_post_enqueue_error_does_not_rollback(monkeypatch):
+    import asyncio
+
+    from pypepper.scheduler.channel import manager
     from pypepper.scheduler.job import Processor
 
     async def send_then_boom(job, chan, *, on_enqueued=None):
@@ -533,14 +568,52 @@ def test_post_enqueue_error_does_not_rollback(monkeypatch):
         raise RuntimeError("after-send")
 
     monkeypatch.setattr(Processor, "async_run", staticmethod(send_then_boom))
-    job = Job(category="x", channel_id="post-enqueue")
-    with pytest.raises(RuntimeError, match="after-send"):
-        job.scheduled()
+    channel_id = "post-enqueue"
+    chan = Channel()
+    manager.put(channel_id, chan)
+    try:
+        job = Job(category="x", channel_id=channel_id)
+        with pytest.raises(RuntimeError, match="after-send"):
+            job.scheduled()
 
-    assert job._fsm.current().value == Status.SCHEDULED
-    assert job.status == Status.SCHEDULED.value
-    assert Job.get_saved(job.id) is not None
-    assert Job.get_saved(job.id).status == Status.SCHEDULED.value
+        assert job._fsm.current().value == Status.SCHEDULED
+        assert job.status == Status.SCHEDULED.value
+        assert Job.get_saved(job.id) is not None
+        assert Job.get_saved(job.id).status == Status.SCHEDULED.value
+        # Committed enqueue: job remains receivable on the channel.
+        received = asyncio.run(chan.receive())
+        assert received is job
+    finally:
+        manager.remove(channel_id)
+
+
+def test_mongo_disconnect_benign_continues(monkeypatch):
+    from pypepper.scheduler.store import mongodb as mongodb_mod
+
+    connects: list[dict] = []
+
+    def fake_disconnect(alias=None):
+        raise RuntimeError(f"Connection with alias '{alias}' has not been created")
+
+    def fake_connect(**kwargs):
+        connects.append(kwargs)
+
+    monkeypatch.setattr(mongodb_mod, "disconnect", fake_disconnect)
+    monkeypatch.setattr(mongodb_mod, "mongo_connect", fake_connect)
+    mongodb_mod.MongoJobStore(uri="mongodb://localhost/test", alias="benign-alias")
+    assert connects and connects[0].get("alias") == "benign-alias"
+
+
+def test_mongo_disconnect_non_benign_raises(monkeypatch):
+    from pypepper.scheduler.store import mongodb as mongodb_mod
+
+    def fake_disconnect(alias=None):
+        raise RuntimeError("authentication failed during close")
+
+    monkeypatch.setattr(mongodb_mod, "disconnect", fake_disconnect)
+    monkeypatch.setattr(mongodb_mod, "mongo_connect", lambda **kwargs: None)
+    with pytest.raises(RuntimeError, match="authentication failed"):
+        mongodb_mod.MongoJobStore(uri="mongodb://localhost/test", alias="hard-fail-alias")
 
 
 def test_channel_full_then_retry_succeeds():

--- a/tests/scheduler/test_job_store_memory.py
+++ b/tests/scheduler/test_job_store_memory.py
@@ -472,3 +472,50 @@ def test_channel_full_rolls_back_and_deletes_scheduled():
         assert Job.get_saved(job.id) is None
     finally:
         manager.remove(channel_id)
+
+
+class _FailDeleteStore(InMemoryJobStore):
+    def delete(self, job_id: str) -> None:
+        raise RuntimeError("delete-failed")
+
+
+def test_channel_full_delete_failure_still_raises_channel_full():
+    import asyncio
+
+    from pypepper.scheduler.channel import manager
+    from pypepper.scheduler.job import ChannelFullError
+
+    set_job_store(_FailDeleteStore())
+    channel_id = "bounded-full-delete-fail"
+    bounded = Channel(maxsize=1)
+    assert asyncio.run(bounded.send("occupier")) is True
+    manager.put(channel_id, bounded)
+    try:
+        job = Job(category="x", channel_id=channel_id)
+        with pytest.raises(ChannelFullError, match="channel full"):
+            job.scheduled()
+
+        assert job._fsm.current().value == Status.UNKNOWN
+        assert job.status == Status.UNKNOWN.value
+        # Best-effort delete failed: Scheduled ghost may remain.
+        ghost = Job.get_saved(job.id)
+        assert ghost is not None
+        assert ghost.status == Status.SCHEDULED.value
+    finally:
+        manager.remove(channel_id)
+
+
+def test_enqueue_failure_rolls_back_for_any_error(monkeypatch):
+    from pypepper.scheduler.job import Processor
+
+    def boom(self, job, chan):
+        raise RuntimeError("enqueue-boom")
+
+    monkeypatch.setattr(Processor, "run", boom)
+    job = Job(category="x", channel_id="enqueue-any-error")
+    with pytest.raises(RuntimeError, match="enqueue-boom"):
+        job.scheduled()
+
+    assert job._fsm.current().value == Status.UNKNOWN
+    assert job.status == Status.UNKNOWN.value
+    assert Job.get_saved(job.id) is None

--- a/tests/scheduler/test_job_store_memory.py
+++ b/tests/scheduler/test_job_store_memory.py
@@ -66,7 +66,7 @@ def test_memory_put_upserts():
             category="b",
             channel_id="ch",
             status=Status.COMPLETED.value,
-            created="t0",
+            created="should-not-overwrite",
             updated="t1",
         )
     )
@@ -74,6 +74,7 @@ def test_memory_put_upserts():
     assert got is not None
     assert got.category == "b"
     assert got.status == Status.COMPLETED.value
+    assert got.created == "t0"
 
 
 def test_scheduled_persists_scheduled_status():
@@ -508,7 +509,7 @@ def test_channel_full_delete_failure_still_raises_channel_full():
 def test_enqueue_failure_rolls_back_for_any_error(monkeypatch):
     from pypepper.scheduler.job import Processor
 
-    def boom(self, job, chan):
+    def boom(self, job, chan, *, on_enqueued=None):
         raise RuntimeError("enqueue-boom")
 
     monkeypatch.setattr(Processor, "run", boom)
@@ -519,3 +520,50 @@ def test_enqueue_failure_rolls_back_for_any_error(monkeypatch):
     assert job._fsm.current().value == Status.UNKNOWN
     assert job.status == Status.UNKNOWN.value
     assert Job.get_saved(job.id) is None
+
+
+def test_post_enqueue_error_does_not_rollback(monkeypatch):
+    from pypepper.scheduler.job import Processor
+
+    async def send_then_boom(job, chan, *, on_enqueued=None):
+        ok = await chan.send(job)
+        assert ok is True
+        if on_enqueued is not None:
+            on_enqueued()
+        raise RuntimeError("after-send")
+
+    monkeypatch.setattr(Processor, "async_run", staticmethod(send_then_boom))
+    job = Job(category="x", channel_id="post-enqueue")
+    with pytest.raises(RuntimeError, match="after-send"):
+        job.scheduled()
+
+    assert job._fsm.current().value == Status.SCHEDULED
+    assert job.status == Status.SCHEDULED.value
+    assert Job.get_saved(job.id) is not None
+    assert Job.get_saved(job.id).status == Status.SCHEDULED.value
+
+
+def test_channel_full_then_retry_succeeds():
+    import asyncio
+
+    from pypepper.scheduler.channel import manager
+    from pypepper.scheduler.job import ChannelFullError
+
+    channel_id = "bounded-retry"
+    bounded = Channel(maxsize=1)
+    assert asyncio.run(bounded.send("occupier")) is True
+    manager.put(channel_id, bounded)
+    try:
+        job = Job(category="x", channel_id=channel_id)
+        with pytest.raises(ChannelFullError):
+            job.scheduled()
+        assert job._fsm.current().value == Status.UNKNOWN
+        assert Job.get_saved(job.id) is None
+
+        assert asyncio.run(bounded.receive()) == "occupier"
+        job.scheduled()
+        assert job._fsm.current().value == Status.SCHEDULED
+        assert Job.get_saved(job.id) is not None
+        assert Job.get_saved(job.id).status == Status.SCHEDULED.value
+    finally:
+        manager.remove(channel_id)

--- a/tests/scheduler/test_job_store_memory.py
+++ b/tests/scheduler/test_job_store_memory.py
@@ -232,8 +232,10 @@ async def test_run_save_failure_marks_job_failed():
 @pytest.mark.asyncio
 async def test_complete_save_failure_keeps_completed_fsm():
     set_job_store(_FailingStore())
+    executed = []
 
     def work(task, context):
+        executed.append(task.name)
         return "ok"
 
     job = _job_with_workflow(work)
@@ -245,10 +247,33 @@ async def test_complete_save_failure_keeps_completed_fsm():
         await Worker(chan).run_once()
 
     # Work finished: keep Completed; retry job.save() only (store may still be InProgress).
+    assert executed == ["step1"]
     assert job._fsm.current().value == Status.COMPLETED
+    assert job.status == Status.IN_PROGRESS.value
+    assert job.to_record().status == Status.COMPLETED.value
     saved = Job.get_saved(job.id)
     assert saved is not None
     assert saved.status == Status.IN_PROGRESS.value
+
+    # Retry save only (no re-run) after store accepts COMPLETED.
+    reset_job_store()
+    # Seed last durable InProgress then overwrite via save from Completed FSM.
+    get_job_store().put(
+        JobRecord(
+            id=job.id,
+            category=job.category,
+            channel_id=job.channel_id,
+            status=Status.IN_PROGRESS.value,
+            created=job.created,
+            updated=job.updated,
+            workflow_count=1,
+            version=1,
+        )
+    )
+    job.save()
+    assert executed == ["step1"]
+    assert Job.get_saved(job.id).status == Status.COMPLETED.value
+    assert job.status == Status.COMPLETED.value
 
 
 @pytest.mark.asyncio
@@ -267,11 +292,87 @@ async def test_fail_path_save_failure_keeps_failed_fsm():
         await Worker(chan).run_once()
 
     assert "persist-failed" not in str(exc_info.value)
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert "persist-failed" in str(exc_info.value.__cause__)
     # Terminal failure kept; retry job.save() only.
     assert job._fsm.current().value == Status.FAILED
+    assert job.status == Status.IN_PROGRESS.value
+    assert job.to_record().status == Status.FAILED.value
     saved = Job.get_saved(job.id)
     assert saved is not None
     assert saved.status == Status.IN_PROGRESS.value
+
+    reset_job_store()
+    get_job_store().put(
+        JobRecord(
+            id=job.id,
+            category=job.category,
+            channel_id=job.channel_id,
+            status=Status.IN_PROGRESS.value,
+            created=job.created,
+            updated=job.updated,
+            workflow_count=1,
+            version=1,
+        )
+    )
+    job.save()
+    assert Job.get_saved(job.id).status == Status.FAILED.value
+
+
+class _FailOnInProgressAndFailedStore(InMemoryJobStore):
+    def put(self, record: JobRecord) -> None:
+        if record.status in (Status.IN_PROGRESS.value, Status.FAILED.value):
+            raise RuntimeError("run-and-fail-persist-failed")
+        super().put(record)
+
+
+@pytest.mark.asyncio
+async def test_run_and_fail_persist_both_fail_restores_pre_run():
+    set_job_store(_FailOnInProgressAndFailedStore())
+    executed = []
+
+    def work(task, context):
+        executed.append(task.name)
+        return "ok"
+
+    job = _job_with_workflow(work)
+    job.save()
+    assert job.status == Status.SCHEDULED.value
+    chan = Channel()
+    await chan.send(job)
+
+    with pytest.raises(RuntimeError, match="run-and-fail-persist-failed"):
+        await Worker(chan).run_once()
+
+    assert executed == []
+    assert job._fsm.current().value == Status.SCHEDULED
+    assert job.status == Status.SCHEDULED.value
+    saved = Job.get_saved(job.id)
+    assert saved is not None
+    assert saved.status == Status.SCHEDULED.value
+
+
+@pytest.mark.asyncio
+async def test_invalid_run_transition_does_not_execute_workflows():
+    from pypepper.exceptions import InternalException
+
+    executed = []
+
+    def work(task, context):
+        executed.append(task.name)
+        return "ok"
+
+    job = _job_with_workflow(work)
+    # Leave job Scheduled in store/FSM but force FSM to Completed so RUN is invalid.
+    job.apply_event(events.RUN)
+    job.apply_event(events.COMPLETE)
+    chan = Channel()
+    await chan.send(job)
+
+    with pytest.raises(InternalException):
+        await Worker(chan).run_once()
+
+    assert executed == []
 
 
 def test_dispatch_save_failure_rolls_back_for_retry():
@@ -282,21 +383,26 @@ def test_dispatch_save_failure_rolls_back_for_retry():
         job.scheduled()
 
     assert job._fsm.current().value == Status.UNKNOWN
+    assert job.status == Status.UNKNOWN.value
     assert Job.get_saved(job.id) is None
 
     reset_job_store()
     job.scheduled()
     assert Job.get_saved(job.id) is not None
     assert Job.get_saved(job.id).status == Status.SCHEDULED.value
+    assert job.status == Status.SCHEDULED.value
 
 
 def test_sql_missing_connection_raises_value_error():
+    from pypepper.scheduler.store.mongodb import MongoJobStore
     from pypepper.scheduler.store.sql import SqlJobStore
 
     with pytest.raises(ValueError, match="postgres job store requires"):
         SqlJobStore(backend="postgres", host="localhost")
     with pytest.raises(ValueError, match="mysql job store requires"):
         SqlJobStore(backend="mysql", host="localhost")
+    with pytest.raises(ValueError, match="mongodb job store requires"):
+        MongoJobStore(host="localhost")
 
 
 def test_setup_from_config_memory_preserves_existing_store():
@@ -362,6 +468,7 @@ def test_channel_full_rolls_back_and_deletes_scheduled():
             job.scheduled()
 
         assert job._fsm.current().value == Status.UNKNOWN
+        assert job.status == Status.UNKNOWN.value
         assert Job.get_saved(job.id) is None
     finally:
         manager.remove(channel_id)


### PR DESCRIPTION
## Summary

- Problem: `Job.save()` was a log-only stub; scheduler had no durable job metadata and incomplete persist-failure semantics.
- Why it matters: Callers need inspectable job status across schedule/run/complete/fail, with clear rules when DB writes fail.
- What changed: Pluggable `IJobStore` with `memory` (default), `postgres`, `mysql`, and `mongodb`; lifecycle saves; pre-execution rollback (schedule/enqueue); keep terminal FSM on COMPLETE/FAIL persist failure; docs in `AGENTS.md` + scheduler guide.
- What did NOT change: No executor/workflow serialization; no Redis/file backends; retry_until_completed / round_timeout still unwired.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] common
- [ ] event
- [ ] fsm
- [ ] helper
- [ ] network
- [x] scheduler
- [x] CI/CD / infra

## Linked Issue/PR

- Related: scheduler depth / Job.save persistence

## User-visible / Behavior Changes

- `Job.save()` upserts `JobRecord` into the process-wide store (default in-memory).
- Optional YAML `scheduler.jobStore` (`memory` | `postgres` | `mysql` | `mongodb`).
- `configure_job_store(...)` / `Job.get_saved(id)` for programmatic use.
- Bounded channel full raises `ChannelFullError` and rolls back Scheduled snapshot.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes` — optional DB connections when a DB backend is configured)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`Yes` — job metadata persisted to configured DB when enabled)
- If any `Yes`, explain risk + mitigation: DB credentials via app config / URI; default remains memory with no external I/O.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local `.venv` + `devenv` MySQL/Postgres/Mongo
- Relevant config (redacted): `scheduler.jobStore.backend: memory` default

### Steps

1. `PATH=".venv/bin:$PATH" make test`
2. Exercise `configure_job_store("postgres", uri=...)` + `job.scheduled()` / worker path as in docs

### Expected

- Tests green; coverage ≥ 90%; schedule/enqueue failures roll back; terminal persist failure keeps FSM

### Actual

- 157 passed locally; coverage ~92.3%

## Evidence

- [x] `make test` — 157 passed, cov-fail-under 90
- [x] Memory + DB integration tests under `tests/scheduler/test_job_store_*.py`

## Human Verification (required)

- Verified: memory lifecycle, postgres/mysql/mongodb CRUD, channel-full rollback, persist-failure semantics
- Not verified: production Trusted Publisher / multi-process recovery of terminal-but-unpersisted jobs

## Test plan

- [x] `make test` with devenv DBs up
- [ ] CI green on this PR
- [ ] Spot-check docs: Persistence section in scheduler guide