### PR TITLE
refactor(common): decouple job store setup from config load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,6 @@
 - **Do not** declare mutable instance state as class attributes (`_store = {}`, `_lock = Lock()`). Initialize dicts/lists/locks in `__init__` or `__new__`.
 - Global registries (`dispatcher`, `connection_manager`, `loader`, channel `manager`) must be **explicit singletons** (module-level instance and/or `__new__`), never accidental shared class dicts.
 - Run `python scripts/check_mutable_class_attrs.py` (also via `make check` / `make test`) before opening a PR.
-- **Do not** declare mutable instance state as class attributes (`_store = {}`, `_lock = Lock()`). Initialize dicts/lists/locks in `__init__` or `__new__`.
-- Global registries (`dispatcher`, `connection_manager`, `loader`, channel `manager`) must be **explicit singletons** (module-level instance and/or `__new__`), never accidental shared class dicts.
-- Run `python scripts/check_mutable_class_attrs.py` (also via `make check` / `make test`) before opening a PR.
 
 ## Scheduler persistence semantics
 Job snapshots (`JobRecord`) are metadata-only (workflows/executors are not serialized). Treat side effects as the source of truth when deciding rollback vs keep-terminal:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 
 ### Changed
 - `config.load_config()` no longer configures the scheduler job store; apps call `scheduler.store.setup_from_config` explicitly after load.
-- `Job.scheduled()` / `Processor.run` raise `RuntimeError` when an event loop is already running.
+- `config.load_config()` warns when YAML declares a non-`memory` `scheduler.jobStore.backend` that has not been applied.
+- `Job.scheduled()` / `Processor.run` raise `RuntimeError` when an event loop is already running; async callers must `INIT`→`SCHEDULE`, `save()`, then `await Channel.send` + `Worker`.
 
 ### Fixed
 - Scheduler persist-failure semantics: roll back pre-execution schedule failures; keep terminal COMPLETE/FAIL when snapshot write fails (retry `save` only).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Added
 - Pluggable scheduler `Job.save` store with `memory` (default), `postgres`, `mysql`, and `mongodb` backends.
 
+### Changed
+- `config.load_config()` no longer configures the scheduler job store; apps call `scheduler.store.setup_from_config` explicitly after load.
+- `Job.scheduled()` / `Processor.run` raise `RuntimeError` when an event loop is already running.
+
 ### Fixed
 - Scheduler persist-failure semantics: roll back pre-execution schedule failures; keep terminal COMPLETE/FAIL when snapshot write fails (retry `save` only).
 - SQL job store raises `ValueError` for incomplete connection config instead of `AssertionError`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,10 +24,10 @@ flowchart TB
 
 | Package | Depends on | Notes |
 |---------|------------|-------|
-| `common` | (none of other domains) | Shared kernel |
+| `common` | (none of other domains) | Shared kernel; does not import `scheduler` |
 | `event` | `common` | Signed events |
 | `fsm` | `event`, `errors` | Generic state machine |
-| `scheduler` | `common`, `event`, `fsm` | Job pipeline |
+| `scheduler` | `common`, `event`, `fsm` | Job pipeline; job store wired via `setup_from_config` / `configure_job_store` (not by `config.load_config`) |
 | `network` | `common` | HTTP + SSE; no scheduler coupling |
 | `helper` | (standalone) | DB connect helpers only |
 

--- a/docs/guides/common.md
+++ b/docs/guides/common.md
@@ -16,7 +16,9 @@ print(yml.sse.authentication.enabled)
 `load_config()` without a path uses CLI `--config` or the default `./conf/app.config.yaml`.
 It applies log level and optional tracing setup. It does **not** configure the scheduler job
 store — call `pypepper.scheduler.store.setup_from_config(config.get_yml_config())` after load
-when YAML includes `scheduler.jobStore` (see [Scheduler](scheduler.md)).
+when YAML includes `scheduler.jobStore` (see [Scheduler](scheduler.md)). If YAML declares a
+non-`memory` `jobStore.backend`, `load_config` logs a warning until you call
+`setup_from_config`.
 
 ## Logging
 

--- a/docs/guides/common.md
+++ b/docs/guides/common.md
@@ -14,6 +14,9 @@ print(yml.sse.authentication.enabled)
 ```
 
 `load_config()` without a path uses CLI `--config` or the default `./conf/app.config.yaml`.
+It applies log level and optional tracing setup. It does **not** configure the scheduler job
+store — call `pypepper.scheduler.store.setup_from_config(config.get_yml_config())` after load
+when YAML includes `scheduler.jobStore` (see [Scheduler](scheduler.md)).
 
 ## Logging
 

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -108,7 +108,7 @@ assert get_job_store().get(job.id) is not None
 ```
 
 YAML (optional). `config.load_config()` does **not** apply this automatically — call
-`setup_from_config` after load:
+`setup_from_config` after load (a durable `backend` without that call logs a warning):
 
 ```python
 from pypepper.common.config import config
@@ -129,8 +129,8 @@ Connections reuse [`helper.db`](helper-db.md) settings style (`uri` or discrete 
 `Worker` also calls `save()` after `RUN` / `COMPLETE` / `FAIL`.
 
 `Job.scheduled()` / `Processor.run` must be called from a **sync** context. They raise
-`RuntimeError` if an event loop is already running; from async code, enqueue with
-`await Channel.send(job)` and consume with `Worker` instead.
+`RuntimeError` if an event loop is already running. From async code: apply `INIT` then
+`SCHEDULE`, call `job.save()`, then `await Channel.send(job)` and consume with `Worker`.
 
 ### Persist-failure rules
 

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -107,7 +107,16 @@ assert saved.status == "Scheduled"
 assert get_job_store().get(job.id) is not None
 ```
 
-YAML (optional):
+YAML (optional). `config.load_config()` does **not** apply this automatically — call
+`setup_from_config` after load:
+
+```python
+from pypepper.common.config import config
+from pypepper.scheduler.store import setup_from_config
+
+config.load_config("./conf/app.config.yaml")
+setup_from_config(config.get_yml_config())
+```
 
 ```yaml
 scheduler:
@@ -118,6 +127,10 @@ scheduler:
 
 Connections reuse [`helper.db`](helper-db.md) settings style (`uri` or discrete host/user/password/db).
 `Worker` also calls `save()` after `RUN` / `COMPLETE` / `FAIL`.
+
+`Job.scheduled()` / `Processor.run` must be called from a **sync** context. They raise
+`RuntimeError` if an event loop is already running; from async code, enqueue with
+`await Channel.send(job)` and consume with `Worker` instead.
 
 ### Persist-failure rules
 

--- a/docs/guides/tracing.md
+++ b/docs/guides/tracing.md
@@ -30,7 +30,8 @@ tracing:
 | `enabled: true` + `otlp.enabled: true` | OTLP HTTP → `{endpoint}/v1/traces` |
 | Both console and otlp | Spans go to terminal **and** collector |
 
-`config.load_config()` calls `setup_from_config()` automatically.
+`config.load_config()` calls tracing `setup_from_config()` automatically. It does **not**
+configure the scheduler job store (call `scheduler.store.setup_from_config` separately).
 
 ## Console (logs)
 

--- a/example/server/app.py
+++ b/example/server/app.py
@@ -6,6 +6,7 @@ from pypepper.common.log import log
 from pypepper.logo import logo
 from pypepper.network.http import server
 from pypepper.network.http.interfaces import ITaskHandler
+from pypepper.scheduler.store import setup_from_config as setup_job_store_from_config
 
 
 def biz1():
@@ -38,6 +39,7 @@ def main():
     log.logo(logo)
     system.handle_signals()
     config.load_config()
+    setup_job_store_from_config(config.get_yml_config())
 
     server.run(app_handlers)
 

--- a/example/sse/app.py
+++ b/example/sse/app.py
@@ -32,7 +32,7 @@ from pypepper.network.http.sse.handlers import EchoSSEHandler, CounterSSEHandler
 from pypepper.network.http.sse.interfaces import ISSEConnection, ISSEHandler, ISSEEvent
 from pypepper.network.http.sse.security import require_sse_api_key
 from pypepper.network.http.sse.stream import sse_stream
-
+from pypepper.scheduler.store import setup_from_config as setup_job_store_from_config
 app = FastAPI(title="PyPepper SSE Example")
 
 
@@ -180,6 +180,7 @@ def main():
 
     # Load configuration
     config.load_config()
+    setup_job_store_from_config(config.get_yml_config())
     demo_key = _inject_demo_api_key_from_env()
 
     # Log SSE configuration

--- a/pypepper/common/config.py
+++ b/pypepper/common/config.py
@@ -155,10 +155,8 @@ class Config:
             log.set_colorize(self.get_yml_config().log.colorize)
 
         from pypepper.common.tracing import setup_from_config
-        from pypepper.scheduler.store import setup_from_config as setup_job_store_from_config
 
         setup_from_config(self.get_yml_config())
-        setup_job_store_from_config(self.get_yml_config())
 
     def get_yml_config(self) -> YmlConfig:
         return self._setting

--- a/pypepper/common/config.py
+++ b/pypepper/common/config.py
@@ -157,6 +157,26 @@ class Config:
         from pypepper.common.tracing import setup_from_config
 
         setup_from_config(self.get_yml_config())
+        self._warn_if_scheduler_job_store_deferred()
+
+    def _warn_if_scheduler_job_store_deferred(self) -> None:
+        """Warn when YAML declares a durable jobStore that load_config does not apply."""
+        yml = self.get_yml_config()
+        if yml is None or not hasattr(yml, "scheduler") or yml.scheduler is None:
+            return
+        job_store = getattr(yml.scheduler, "jobStore", None)
+        if job_store is None:
+            return
+        backend = getattr(job_store, "backend", None)
+        if backend is None:
+            return
+        name = str(backend).strip().lower()
+        if name in ("", "memory"):
+            return
+        log.warn(
+            f"scheduler.jobStore.backend={backend!r} is present in YAML but not applied by "
+            "load_config; call pypepper.scheduler.store.setup_from_config(...) after load"
+        )
 
     def get_yml_config(self) -> YmlConfig:
         return self._setting

--- a/pypepper/scheduler/job.py
+++ b/pypepper/scheduler/job.py
@@ -38,13 +38,13 @@ class Processor:
         try:
             asyncio.get_running_loop()
         except RuntimeError:
-            pass
-        else:
-            raise RuntimeError(
-                "Processor.run / Job.scheduled() must be called from a sync context "
-                "(no running event loop); use Channel.send + Worker from async code instead"
-            )
-        asyncio.run(self.async_run(job, chan, on_enqueued=on_enqueued))
+            asyncio.run(self.async_run(job, chan, on_enqueued=on_enqueued))
+            return
+        raise RuntimeError(
+            "Processor.run / Job.scheduled() must be called from a sync context "
+            "(no running event loop); from async code apply INIT→SCHEDULE, call "
+            "job.save(), then await Channel.send(job) and consume with Worker"
+        )
 
     @staticmethod
     async def async_run(

--- a/pypepper/scheduler/job.py
+++ b/pypepper/scheduler/job.py
@@ -35,6 +35,15 @@ def _raise_if_transition_failed(resp_error: object) -> None:
 
 class Processor:
     def run(self, job: Job, chan: Channel, *, on_enqueued: Callable[[], None] | None = None) -> None:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+        else:
+            raise RuntimeError(
+                "Processor.run / Job.scheduled() must be called from a sync context "
+                "(no running event loop); use Channel.send + Worker from async code instead"
+            )
         asyncio.run(self.async_run(job, chan, on_enqueued=on_enqueued))
 
     @staticmethod

--- a/tests/common/test_common_config.py
+++ b/tests/common/test_common_config.py
@@ -1,13 +1,26 @@
-import pytest
-
 from pypepper.common.config import config
+from pypepper.scheduler.store import get_job_store, reset_job_store
+from pypepper.scheduler.store.memory import InMemoryJobStore
 
 
 def test_load_config():
-    config.load_config('./conf/app.config.yaml')
+    config.load_config("./conf/app.config.yaml")
     result = config.get_yml_config()
     assert result is not None
     assert result.network.httpServer.port == 55550
-    assert result.log.level == 'TRACE'
+    assert result.log.level == "TRACE"
     assert result.sse.maxTotalConnections == 100
     assert list(result.sse.authentication.validKeys) == []
+
+
+def test_load_config_does_not_configure_job_store():
+    """common.config must not import or call scheduler.store (layering)."""
+    import pypepper.common.config as config_mod
+
+    assert "scheduler.store" not in open(config_mod.__file__).read()
+
+    reset_job_store()
+    config.load_config("./conf/app.config.yaml")
+    assert isinstance(get_job_store(), InMemoryJobStore)
+    # YAML may declare scheduler.jobStore; apps must call setup_from_config explicitly.
+    assert config.get_yml_config().scheduler is not None

--- a/tests/common/test_common_config.py
+++ b/tests/common/test_common_config.py
@@ -1,4 +1,5 @@
 from pypepper.common.config import config
+from pypepper.common.log import log
 from pypepper.scheduler.store import get_job_store, reset_job_store
 from pypepper.scheduler.store.memory import InMemoryJobStore
 
@@ -13,14 +14,49 @@ def test_load_config():
     assert list(result.sse.authentication.validKeys) == []
 
 
-def test_load_config_does_not_configure_job_store():
+def test_load_config_does_not_configure_job_store(monkeypatch, tmp_path):
     """common.config must not import or call scheduler.store (layering)."""
     import pypepper.common.config as config_mod
+    import pypepper.scheduler.store as store_mod
 
-    assert "scheduler.store" not in open(config_mod.__file__).read()
+    src = open(config_mod.__file__).read()
+    assert "from pypepper.scheduler.store" not in src
+    assert "import pypepper.scheduler.store" not in src
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        store_mod,
+        "setup_from_config",
+        lambda *a, **k: calls.append("setup_from_config"),
+    )
+    monkeypatch.setattr(
+        store_mod,
+        "configure_job_store",
+        lambda *a, **k: calls.append("configure_job_store"),
+    )
+
+    # Durable backend in YAML would reconfigure the store if setup were wired back.
+    cfg = tmp_path / "durable-jobstore.yaml"
+    cfg.write_text(
+        "scheduler:\n"
+        "  jobStore:\n"
+        "    backend: postgres\n"
+        "    uri: postgresql+psycopg://postgres:example@localhost:5432/mock_pypepper\n"
+    )
 
     reset_job_store()
-    config.load_config("./conf/app.config.yaml")
+    warns: list[str] = []
+    monkeypatch.setattr(log, "warn", lambda msg, *a, **k: warns.append(str(msg)))
+    config.load_config(str(cfg))
+
+    assert calls == []
     assert isinstance(get_job_store(), InMemoryJobStore)
-    # YAML may declare scheduler.jobStore; apps must call setup_from_config explicitly.
-    assert config.get_yml_config().scheduler is not None
+    assert any("setup_from_config" in w for w in warns)
+
+
+def test_load_config_memory_job_store_does_not_warn(monkeypatch):
+    warns: list[str] = []
+    monkeypatch.setattr(log, "warn", lambda msg, *a, **k: warns.append(str(msg)))
+    reset_job_store()
+    config.load_config("./conf/app.config.yaml")
+    assert not any("jobStore" in w for w in warns)

--- a/tests/scheduler/test_job_store_db.py
+++ b/tests/scheduler/test_job_store_db.py
@@ -181,37 +181,43 @@ class _FailDeleteProxy(IJobStore):
 
 
 @pytest.mark.parametrize(("backend", "uri"), _BACKENDS)
-def test_db_put_failure_propagates(backend: str, uri: str):
+def test_db_scheduled_put_failure_rolls_back(backend: str, uri: str):
+    """Schedule-path put failure must not leave a durable row or advanced lifecycle."""
     inner = configure_job_store(backend, uri=uri)
     inner.clear()
     set_job_store(_FailPutProxy(inner))
-    record = JobRecord(
-        id=f"fail-put-{backend}",
-        category="x",
-        channel_id=f"ch-{backend}",
-        status=Status.SCHEDULED.value,
-        created="t0",
-        updated="t0",
-    )
+    job = Job(category="x", channel_id=f"ch-fail-put-{backend}")
     with pytest.raises(RuntimeError, match="proxy-put-failed"):
-        get_job_store().put(record)
-    assert inner.get(record.id) is None
+        job.scheduled()
+    assert job._fsm.current().value == Status.UNKNOWN
+    assert job.status == Status.UNKNOWN.value
+    assert inner.get(job.id) is None
 
 
 @pytest.mark.parametrize(("backend", "uri"), _BACKENDS)
-def test_db_delete_failure_propagates(backend: str, uri: str):
+def test_db_enqueue_delete_failure_leaves_ghost(backend: str, uri: str):
+    """Channel-full cleanup delete failure may leave a Scheduled ghost on the DB store."""
+    import asyncio
+
+    from pypepper.scheduler.channel import manager
+    from pypepper.scheduler.job import ChannelFullError
+
     inner = configure_job_store(backend, uri=uri)
     inner.clear()
-    record = JobRecord(
-        id=f"fail-del-{backend}",
-        category="x",
-        channel_id=f"ch-{backend}",
-        status=Status.SCHEDULED.value,
-        created="t0",
-        updated="t0",
-    )
-    inner.put(record)
     set_job_store(_FailDeleteProxy(inner))
-    with pytest.raises(RuntimeError, match="proxy-delete-failed"):
-        get_job_store().delete(record.id)
-    assert inner.get(record.id) is not None
+    channel_id = f"db-full-del-{backend}"
+    bounded = Channel(maxsize=1)
+    assert asyncio.run(bounded.send("occupier")) is True
+    manager.put(channel_id, bounded)
+    try:
+        job = Job(category="x", channel_id=channel_id)
+        with pytest.raises(ChannelFullError, match="channel full"):
+            job.scheduled()
+        assert job._fsm.current().value == Status.UNKNOWN
+        assert job.status == Status.UNKNOWN.value
+        ghost = inner.get(job.id)
+        assert ghost is not None
+        assert ghost.status == Status.SCHEDULED.value
+    finally:
+        manager.remove(channel_id)
+        inner.clear()

--- a/tests/scheduler/test_job_store_db.py
+++ b/tests/scheduler/test_job_store_db.py
@@ -9,7 +9,14 @@ from pypepper.scheduler.channel import Channel
 from pypepper.scheduler.executor import CallableExecutor
 from pypepper.scheduler.job import Job
 from pypepper.scheduler.status import Status
-from pypepper.scheduler.store import JobRecord, configure_job_store, get_job_store, reset_job_store
+from pypepper.scheduler.store import (
+    JobRecord,
+    configure_job_store,
+    get_job_store,
+    reset_job_store,
+    set_job_store,
+)
+from pypepper.scheduler.store.interfaces import IJobStore
 from pypepper.scheduler.task import Task
 from pypepper.scheduler.worker import Worker
 from pypepper.scheduler.workflow import Workflow
@@ -17,6 +24,12 @@ from pypepper.scheduler.workflow import Workflow
 POSTGRES_URI = "postgresql+psycopg://postgres:example@localhost:5432/mock_pypepper"
 MYSQL_URI = "mysql+pymysql://root:example@localhost:3306/mock_pypepper?charset=utf8mb4"
 MONGO_URI = "mongodb://test:test@localhost:27017/test"
+
+_BACKENDS = (
+    ("postgres", POSTGRES_URI),
+    ("mysql", MYSQL_URI),
+    ("mongodb", MONGO_URI),
+)
 
 
 @pytest.fixture(autouse=True)
@@ -76,9 +89,8 @@ def test_mongodb_crud():
     _crud_roundtrip("mongodb", MONGO_URI)
 
 
-@pytest.mark.asyncio
-async def test_postgres_worker_lifecycle():
-    configure_job_store("postgres", uri=POSTGRES_URI)
+async def _worker_lifecycle(backend: str, uri: str, channel_id: str) -> None:
+    configure_job_store(backend, uri=uri)
     get_job_store().clear()
 
     def work(task, context):
@@ -97,7 +109,7 @@ async def test_postgres_worker_lifecycle():
             executor=CallableExecutor(work),
         )
     )
-    job = Job(category="pg", channel_id="pg-lifecycle")
+    job = Job(category=backend, channel_id=channel_id)
     job.workflows = [workflow]
     assert job._fsm.on(events.INIT).error is None
     assert job._fsm.on(events.SCHEDULE).error is None
@@ -114,35 +126,92 @@ async def test_postgres_worker_lifecycle():
 
 
 @pytest.mark.asyncio
+async def test_postgres_worker_lifecycle():
+    await _worker_lifecycle("postgres", POSTGRES_URI, "pg-lifecycle")
+
+
+@pytest.mark.asyncio
+async def test_mysql_worker_lifecycle():
+    await _worker_lifecycle("mysql", MYSQL_URI, "mysql-lifecycle")
+
+
+@pytest.mark.asyncio
 async def test_mongodb_worker_lifecycle():
-    configure_job_store("mongodb", uri=MONGO_URI)
-    get_job_store().clear()
+    await _worker_lifecycle("mongodb", MONGO_URI, "mongo-lifecycle")
 
-    def work(task, context):
-        return "ok"
 
-    workflow = Workflow()
-    workflow.add_task(
-        Task(
-            channel_id="ch",
-            dag_id="dag",
-            fingerprint="fp",
-            name="step1",
-            category="c",
-            description="",
-            tags=[],
-            executor=CallableExecutor(work),
-        )
+class _FailPutProxy(IJobStore):
+    def __init__(self, inner: IJobStore) -> None:
+        self._inner = inner
+
+    def put(self, record: JobRecord) -> None:
+        raise RuntimeError("proxy-put-failed")
+
+    def get(self, job_id: str) -> JobRecord | None:
+        return self._inner.get(job_id)
+
+    def delete(self, job_id: str) -> None:
+        self._inner.delete(job_id)
+
+    def list(self, channel_id: str | None = None) -> list[JobRecord]:
+        return self._inner.list(channel_id)
+
+    def clear(self) -> None:
+        self._inner.clear()
+
+
+class _FailDeleteProxy(IJobStore):
+    def __init__(self, inner: IJobStore) -> None:
+        self._inner = inner
+
+    def put(self, record: JobRecord) -> None:
+        self._inner.put(record)
+
+    def get(self, job_id: str) -> JobRecord | None:
+        return self._inner.get(job_id)
+
+    def delete(self, job_id: str) -> None:
+        raise RuntimeError("proxy-delete-failed")
+
+    def list(self, channel_id: str | None = None) -> list[JobRecord]:
+        return self._inner.list(channel_id)
+
+    def clear(self) -> None:
+        self._inner.clear()
+
+
+@pytest.mark.parametrize(("backend", "uri"), _BACKENDS)
+def test_db_put_failure_propagates(backend: str, uri: str):
+    inner = configure_job_store(backend, uri=uri)
+    inner.clear()
+    set_job_store(_FailPutProxy(inner))
+    record = JobRecord(
+        id=f"fail-put-{backend}",
+        category="x",
+        channel_id=f"ch-{backend}",
+        status=Status.SCHEDULED.value,
+        created="t0",
+        updated="t0",
     )
-    job = Job(category="mongo", channel_id="mongo-lifecycle")
-    job.workflows = [workflow]
-    assert job._fsm.on(events.INIT).error is None
-    assert job._fsm.on(events.SCHEDULE).error is None
-    job.save()
+    with pytest.raises(RuntimeError, match="proxy-put-failed"):
+        get_job_store().put(record)
+    assert inner.get(record.id) is None
 
-    chan = Channel()
-    await chan.send(job)
-    await Worker(chan).run_once()
-    saved = Job.get_saved(job.id)
-    assert saved is not None
-    assert saved.status == Status.COMPLETED.value
+
+@pytest.mark.parametrize(("backend", "uri"), _BACKENDS)
+def test_db_delete_failure_propagates(backend: str, uri: str):
+    inner = configure_job_store(backend, uri=uri)
+    inner.clear()
+    record = JobRecord(
+        id=f"fail-del-{backend}",
+        category="x",
+        channel_id=f"ch-{backend}",
+        status=Status.SCHEDULED.value,
+        created="t0",
+        updated="t0",
+    )
+    inner.put(record)
+    set_job_store(_FailDeleteProxy(inner))
+    with pytest.raises(RuntimeError, match="proxy-delete-failed"):
+        get_job_store().delete(record.id)
+    assert inner.get(record.id) is not None

--- a/tests/scheduler/test_job_store_memory.py
+++ b/tests/scheduler/test_job_store_memory.py
@@ -554,6 +554,14 @@ def test_enqueue_failure_rolls_back_for_any_error(monkeypatch):
     assert Job.get_saved(job.id) is None
 
 
+@pytest.mark.asyncio
+async def test_scheduled_raises_when_event_loop_running():
+    job = Job(category="x", channel_id="async-forbidden")
+    with pytest.raises(RuntimeError, match="sync context"):
+        job.scheduled()
+    assert Job.get_saved(job.id) is None
+
+
 def test_post_enqueue_error_does_not_rollback(monkeypatch):
     import asyncio
 


### PR DESCRIPTION
## Summary

- Problem: `config.load_config()` pulled in scheduler job-store setup, coupling `common` to `scheduler` and making durable YAML silently ineffective if callers only load config.
- Why it matters: keeps layering clean after pluggable JobStore (#34); apps must wire stores explicitly; async schedule guidance must match real INIT→SCHEDULE→save→send flow.
- What changed: removed store setup from `load_config`; examples call `setup_from_config`; warn on deferred durable `jobStore`; clearer `Processor.run` async error; MySQL lifecycle + DB failure tests via `scheduled()`/dispatch; layering spy regression.
- What did NOT change (scope boundary): JobStore backends/API, enqueue/rollback semantics from #34, tracing auto-setup.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] common
- [ ] event
- [ ] fsm
- [ ] helper
- [ ] network
- [x] scheduler
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #34 (P0 follow-up: config/store decoupling)

## User-visible / Behavior Changes

- `load_config()` no longer configures the scheduler job store; call `pypepper.scheduler.store.setup_from_config(...)` after load when using YAML `scheduler.jobStore`.
- Non-`memory` `jobStore.backend` in YAML triggers a warning until `setup_from_config` is called.
- `Job.scheduled()` / `Processor.run` raise `RuntimeError` if an event loop is already running; async path docs describe INIT→SCHEDULE, `save()`, then `await Channel.send` + `Worker`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local `.venv` + `devenv/ci.yaml` (postgres/mysql/mongodb)
- Relevant config (redacted): `conf/app.config.yaml` (`jobStore.backend: memory`)

### Steps

1. `docker compose -f devenv/ci.yaml up -d`
2. `PATH=".venv/bin:$PATH" make test`
3. Spot-check: durable YAML without `setup_from_config` leaves `InMemoryJobStore` and logs warn

### Expected

- Tests pass; layering spy never sees store setup from `load_config`; DB put/delete failures exercise schedule/enqueue paths

### Actual

- 176 passed, coverage ~92.6%

## Evidence

- [x] Trace/log snippets — local `make test` (176 passed)

## Human Verification (required)

- Verified scenarios: full `make test` with devenv; layering + memory-warn unit tests; DB scheduled put-fail / channel-full delete-ghost matrix
- Edge cases checked: memory backend does not warn; durable YAML warns without applying store
- What you did **not** verify: GitHub Actions CI on this PR before review; example apps under a live durable backend end-to-end

## Compatibility / Migration

- Backward compatible? (`No` for apps that relied on `load_config` configuring job store)
- Config/env changes? (`Yes` — call `setup_from_config` after load when using non-default store)
- Migration needed? (`Yes`)
- If yes, exact upgrade steps:
  1. After `config.load_config(...)`, call `from pypepper.scheduler.store import setup_from_config` then `setup_from_config(config.get_yml_config())`
  2. See `example/server/app.py` / `example/sse/app.py` and docs/guides/scheduler.md

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR / restore prior `load_config` store hook
- Files/config to restore: `pypepper/common/config.py`, examples, docs
- Known bad symptoms reviewers should watch for: durable YAML configured but jobs stay in memory; unexpected warn on postgres/mysql/mongodb backends

## Risks and Mitigations

- Risk: Existing apps that only called `load_config` keep using in-memory store despite durable YAML
  - Mitigation: warning on non-memory backend; docs + examples updated; layering regression test
- Risk: Async callers still misuse `scheduled()`
  - Mitigation: clearer RuntimeError text + guide wording aligned with INIT→SCHEDULE→save→send

## Test plan

- [x] `make test` with `devenv/ci.yaml`
- [ ] CI green on this PR
- [ ] Confirm example bootstrap still loads with `setup_from_config`