### PR TITLE
feat: harden DX, helper safety, and SSE footguns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - `config.load_config()` no longer configures the scheduler job store; apps call `scheduler.store.setup_from_config` explicitly after load.
 - `config.load_config()` warns when YAML declares a non-`memory` `scheduler.jobStore.backend` that has not been applied.
 - `Job.scheduled()` / `Processor.run` raise `RuntimeError` when an event loop is already running; async callers must `INIT`→`SCHEDULE`, `save()`, then `await Channel.send` + `Worker`.
-- Helper DB connectors raise `ValueError` (not `assert`) for incomplete config; discrete SQL URIs use `quote_plus` for credentials.
+- Helper DB connectors raise `ValueError` (not `assert`) for falsy config / incomplete SQL discrete fields (Mongo only rejects falsy `cfg`); discrete SQL URIs use `quote_plus` for credentials.
 - SSE warns once when authentication is disabled; guide documents auth-off / rate-limit footguns.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 ### Added
 - Pluggable scheduler `Job.save` store with `memory` (default), `postgres`, `mysql`, and `mongodb` backends.
+- Curated domain re-exports (for example `from pypepper.scheduler import Job`); `common.config` / `common.log` stay submodule imports to avoid shadowing.
+- `SECURITY.md` vulnerability reporting policy.
 
 ### Changed
 - `config.load_config()` no longer configures the scheduler job store; apps call `scheduler.store.setup_from_config` explicitly after load.
 - `config.load_config()` warns when YAML declares a non-`memory` `scheduler.jobStore.backend` that has not been applied.
 - `Job.scheduled()` / `Processor.run` raise `RuntimeError` when an event loop is already running; async callers must `INIT`→`SCHEDULE`, `save()`, then `await Channel.send` + `Worker`.
+- Helper DB connectors raise `ValueError` (not `assert`) for incomplete config; discrete SQL URIs use `quote_plus` for credentials.
+- SSE warns once when authentication is disabled; guide documents auth-off / rate-limit footguns.
 
 ### Fixed
 - Scheduler persist-failure semantics: roll back pre-execution schedule failures; keep terminal COMPLETE/FAIL when snapshot write fails (retry `save` only).

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ PyPepper packages the pieces you wire into services: **HTTP / SSE**, **FSM**, a 
 
 Source under [`docs/`](docs/index.md). Local preview: `make docs-serve`.
 
+## Security
+
+See [`SECURITY.md`](SECURITY.md) for supported versions and how to report vulnerabilities privately.
+
 ## Domains
 
 | | Package | Role |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are applied to the latest released version on PyPI and to `main`.
+Older releases may not receive backports.
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security-sensitive reports.
+
+Prefer one of:
+
+1. [GitHub Security Advisories](https://github.com/jovijovi/pypepper/security/advisories/new)
+   (private vulnerability reporting), or
+2. Contact the maintainers via the email listed on the
+   [GitHub profile](https://github.com/jovijovi) / PyPI project page if advisories
+   are unavailable.
+
+Include:
+
+- Affected version / commit
+- Impact and attack scenario
+- Minimal reproduction steps (if possible)
+
+## What to expect
+
+- Acknowledgement when practical
+- A fix or mitigation timeline communicated privately when possible
+- Credit in the advisory / CHANGELOG when you want it
+
+## Non-vulnerabilities
+
+Misconfiguration of optional features (for example leaving
+`sse.authentication.enabled: false` in production) is documented as an operator
+footgun, not a library vulnerability. See the [SSE guide](https://jovijovi.github.io/pypepper/guides/network-sse/).

--- a/conf/app.config.yaml
+++ b/conf/app.config.yaml
@@ -1,4 +1,4 @@
-# Cluster settings
+# Cluster settings (loaded; unused by runtime servers — reserved metadata)
 cluster:
   name: cluster-name
   id: 5dd31f84-5df2-48c7-b84b-32d25b17a930

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,9 +88,12 @@ Runtime YAML lives in `conf/app.config.yaml`. Models vs runtime:
 | `network.*.timeout` | Reserved (servers hardcode keep-alive timeout) |
 | `log.level` / `log.colorize` | Live |
 | `log.mode` | Reserved |
-| `sse.*`, `tracing.*`, `scheduler.jobStore` | Live (job store applied via `setup_from_config`, not `load_config`) |
+| `sse` auth, rate limit, connection caps, `streamTimeoutSeconds`, `maxQueueSize` | Live (read at request/stream time) |
+| `sse.enabled`, `sse.heartbeatIntervalSeconds` | Reserved (loaded; not applied by runtime) |
+| `tracing.*` | Live via `load_config` → tracing `setup_from_config` |
+| `scheduler.jobStore` | Live only after explicit `scheduler.store.setup_from_config` (not `load_config`) |
 | `cluster` | Loaded but unused by runtime |
-| `heartbeat`, `network.jsonRPCProxy` | Reserved (not wired; product work is P2) |
+| `heartbeat`, `network.jsonRPCProxy` | Reserved (not wired yet) |
 | `custom` | App-defined |
 
 ## Observability

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,8 +80,18 @@ sequenceDiagram
 
 ## Config surface
 
-Runtime YAML lives in `conf/app.config.yaml` (cluster, network, log, SSE, tracing, `custom`).
-Some config models (for example heartbeat / JSON-RPC proxy) are reserved and not yet wired to servers.
+Runtime YAML lives in `conf/app.config.yaml`. Models vs runtime:
+
+| Area | Status |
+|------|--------|
+| `network.httpServer` / `httpsServer` (`enable`, `port`, TLS files) | Live |
+| `network.*.timeout` | Reserved (servers hardcode keep-alive timeout) |
+| `log.level` / `log.colorize` | Live |
+| `log.mode` | Reserved |
+| `sse.*`, `tracing.*`, `scheduler.jobStore` | Live (job store applied via `setup_from_config`, not `load_config`) |
+| `cluster` | Loaded but unused by runtime |
+| `heartbeat`, `network.jsonRPCProxy` | Reserved (not wired; product work is P2) |
+| `custom` | App-defined |
 
 ## Observability
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,6 +37,17 @@ make test
 
 ## Run examples
 
+Prefer curated domain imports in application code:
+
+```python
+from pypepper.common.config import config
+from pypepper.scheduler import Job, setup_from_config
+
+config.load_config("./conf/app.config.yaml")
+# Durable scheduler.jobStore backends are not applied by load_config alone:
+setup_from_config(config.get_yml_config())
+```
+
 ### HTTP server
 
 ```shell
@@ -44,6 +55,7 @@ python example/server/app.py --config ./conf/app.config.yaml
 ```
 
 Default HTTP port comes from `conf/app.config.yaml` (`network.httpServer.port`, typically `55550`).
+The example calls `setup_from_config` after `load_config`.
 
 ### SSE example
 
@@ -59,6 +71,9 @@ Connect:
 ```shell
 curl -N -H "X-API-Key: $PYPEPPER_SSE_API_KEY" http://localhost:55550/sse/echo
 ```
+
+Keep `sse.authentication.enabled: true` for anything beyond local experiments
+(see [SSE security notes](guides/network-sse.md#security-notes)).
 
 ## Documentation site
 

--- a/docs/guides/network-sse.md
+++ b/docs/guides/network-sse.md
@@ -78,7 +78,7 @@ async def clock(request: Request):
 ### Security notes
 
 - **Production:** keep `sse.authentication.enabled: true` and inject `validKeys` (do not commit real keys).
-- **Auth off is not anonymous access.** When `authentication.enabled` is `false`, any **non-empty** API key is accepted. The library logs a warning when this path is used.
+- **Auth off is not anonymous access.** When `authentication.enabled` is `false`, any **non-empty** API key is accepted. The library logs a **one-shot** warning (once per process) when this path is used.
 - **Rate limiting is not a security boundary when auth is off.** Limits are bucketed by the presented key string, so clients can rotate keys to bypass quotas. Treat rate limits as abuse soft-control only when authentication is enabled.
 
 See the full working app in [`example/sse/app.py`](https://github.com/jovijovi/pypepper/blob/main/example/sse/app.py).

--- a/docs/guides/network-sse.md
+++ b/docs/guides/network-sse.md
@@ -75,6 +75,12 @@ async def clock(request: Request):
 - Rate limit: `sse.rateLimit.maxRequestsPerMinute`
 - Connection caps: `maxTotalConnections`, `maxConnectionsPerIP`
 
+### Security notes
+
+- **Production:** keep `sse.authentication.enabled: true` and inject `validKeys` (do not commit real keys).
+- **Auth off is not anonymous access.** When `authentication.enabled` is `false`, any **non-empty** API key is accepted. The library logs a warning when this path is used.
+- **Rate limiting is not a security boundary when auth is off.** Limits are bucketed by the presented key string, so clients can rotate keys to bypass quotas. Treat rate limits as abuse soft-control only when authentication is enabled.
+
 See the full working app in [`example/sse/app.py`](https://github.com/jovijovi/pypepper/blob/main/example/sse/app.py).
 
 ```shell

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -2,6 +2,11 @@
 
 Machine-generated reference from the `pypepper` package (signatures, types, and existing docstrings).
 
+Stable curated imports live on domain packages (for example `from pypepper.scheduler import Job`).
+For `common`, use submodule paths (`from pypepper.common.config import config`) so package-level
+names do not shadow `pypepper.common.config` / `pypepper.common.log`. Deep module paths elsewhere
+remain usable but are not a long-term stability guarantee.
+
 | Section | Package focus |
 |---------|---------------|
 | [Common](common.md) | Config, log, context, cache, crypto, tracing |

--- a/pypepper/common/__init__.py
+++ b/pypepper/common/__init__.py
@@ -1,0 +1,7 @@
+"""Shared kernel: config, logging, context, cache, crypto, tracing.
+
+Stable imports use submodules (names would collide at package level)::
+
+    from pypepper.common.config import config
+    from pypepper.common.log import log
+"""

--- a/pypepper/common/config.py
+++ b/pypepper/common/config.py
@@ -37,7 +37,7 @@ class ConfHTTPSServer:
 
 
 class ConfHeartbeat:
-    """Reserved: not wired to a heartbeat server yet (see P2)."""
+    """Reserved: not wired to a heartbeat server yet."""
 
     enable: bool
     port: int
@@ -45,7 +45,7 @@ class ConfHeartbeat:
 
 
 class ConfJsonRPCProxy:
-    """Reserved: not wired to a JSON-RPC proxy yet (see P2)."""
+    """Reserved: not wired to a JSON-RPC proxy yet."""
 
     enable: bool
     port: int
@@ -56,7 +56,7 @@ class ConfNetwork:
     ip: str
     httpServer: ConfHTTPServer
     httpsServer: ConfHTTPSServer
-    jsonRPCProxy: ConfJsonRPCProxy  # reserved
+    jsonRPCProxy: ConfJsonRPCProxy
 
 
 class ConfLog:
@@ -117,9 +117,9 @@ class ConfScheduler:
 
 
 class YmlConfig:
-    cluster: ConfCluster  # reserved / unused by runtime
+    cluster: ConfCluster
     network: ConfNetwork
-    heartbeat: ConfHeartbeat  # reserved
+    heartbeat: ConfHeartbeat
     log: ConfLog
     sse: ConfSSE
     tracing: ConfTracing

--- a/pypepper/common/config.py
+++ b/pypepper/common/config.py
@@ -11,6 +11,8 @@ from pypepper.common.log import log
 
 
 class ConfCluster:
+    """Loaded from YAML ``cluster``; currently unused by runtime servers (reserved)."""
+
     name: str
     id: str
     description: str
@@ -19,6 +21,7 @@ class ConfCluster:
 class ConfHTTPServer:
     enable: bool
     port: int
+    # Reserved: HTTP server currently hardcodes keep-alive timeout.
     timeout: int = 30
 
 
@@ -26,6 +29,7 @@ class ConfHTTPSServer:
     enable: bool
     port: int
     mutualTLS: bool
+    # Reserved: HTTPS server currently hardcodes keep-alive timeout.
     timeout: int = 30
     certFile: str = ""
     keyFile: str = ""
@@ -33,12 +37,16 @@ class ConfHTTPSServer:
 
 
 class ConfHeartbeat:
+    """Reserved: not wired to a heartbeat server yet (see P2)."""
+
     enable: bool
     port: int
     logger: bool
 
 
 class ConfJsonRPCProxy:
+    """Reserved: not wired to a JSON-RPC proxy yet (see P2)."""
+
     enable: bool
     port: int
     mutualTLS: bool
@@ -48,10 +56,11 @@ class ConfNetwork:
     ip: str
     httpServer: ConfHTTPServer
     httpsServer: ConfHTTPSServer
-    jsonRPCProxy: ConfJsonRPCProxy
+    jsonRPCProxy: ConfJsonRPCProxy  # reserved
 
 
 class ConfLog:
+    # Reserved: only ``level`` and ``colorize`` are applied by load_config.
     mode: str
     level: str
     colorize: bool
@@ -98,6 +107,9 @@ class ConfSchedulerJobStore:
     username: str | None
     password: str | None
     db: str | None
+    sslmode: str | None
+    charset: str | None
+    auth_source: str | None
 
 
 class ConfScheduler:
@@ -105,9 +117,9 @@ class ConfScheduler:
 
 
 class YmlConfig:
-    cluster: ConfCluster
+    cluster: ConfCluster  # reserved / unused by runtime
     network: ConfNetwork
-    heartbeat: ConfHeartbeat
+    heartbeat: ConfHeartbeat  # reserved
     log: ConfLog
     sse: ConfSSE
     tracing: ConfTracing

--- a/pypepper/event/__init__.py
+++ b/pypepper/event/__init__.py
@@ -1,0 +1,11 @@
+"""Signed domain events."""
+
+from .event import Data, Event, Header, Payload, new
+
+__all__ = [
+    "Data",
+    "Event",
+    "Header",
+    "Payload",
+    "new",
+]

--- a/pypepper/fsm/__init__.py
+++ b/pypepper/fsm/__init__.py
@@ -1,0 +1,11 @@
+"""Finite state machine primitives."""
+
+from .fsm import FSM, Options, Response, State, Transition
+
+__all__ = [
+    "FSM",
+    "Options",
+    "Response",
+    "State",
+    "Transition",
+]

--- a/pypepper/helper/__init__.py
+++ b/pypepper/helper/__init__.py
@@ -1,0 +1,9 @@
+"""Standalone helpers (database connectors)."""
+
+from pypepper.helper.db import mongodb, mysql, postgres
+
+__all__ = [
+    "mongodb",
+    "mysql",
+    "postgres",
+]

--- a/pypepper/helper/db/__init__.py
+++ b/pypepper/helper/db/__init__.py
@@ -1,0 +1,9 @@
+"""Database connector helpers (MySQL, PostgreSQL, MongoDB)."""
+
+from . import mongodb, mysql, postgres
+
+__all__ = [
+    "mongodb",
+    "mysql",
+    "postgres",
+]

--- a/pypepper/helper/db/mongodb.py
+++ b/pypepper/helper/db/mongodb.py
@@ -42,7 +42,8 @@ class Config(IConfig, metaclass=ABCMeta):
 
 
 def connect(cfg: Config) -> None:
-    assert cfg, "invalid database config"
+    if not cfg:
+        raise ValueError("invalid database config")
 
     if cfg.uri:
         connect_db(

--- a/pypepper/helper/db/mysql.py
+++ b/pypepper/helper/db/mysql.py
@@ -7,6 +7,7 @@ from abc import ABCMeta
 from sqlalchemy import Connection, create_engine
 
 from pypepper.helper.db.interfaces import IConfig
+from pypepper.helper.db.uri import build_mysql_uri
 
 
 class Config(IConfig, metaclass=ABCMeta):
@@ -34,20 +35,33 @@ class Config(IConfig, metaclass=ABCMeta):
 
 
 def connect(cfg: Config) -> Connection:
-    assert cfg, "invalid database config"
+    if not cfg:
+        raise ValueError("invalid database config")
 
     if cfg.uri:
         return create_engine(cfg.uri).connect()
 
-    assert cfg.username, "invalid username"
-    assert cfg.password, "invalid password"
-    assert cfg.host, "invalid host"
-    assert cfg.db, "invalid db"
+    if not cfg.username:
+        raise ValueError("invalid username")
+    if not cfg.password:
+        raise ValueError("invalid password")
+    if not cfg.host:
+        raise ValueError("invalid host")
+    if not cfg.db:
+        raise ValueError("invalid db")
 
-    uri = f"mysql+pymysql://{cfg.username}:{cfg.password}@{cfg.host}:{cfg.port}/{cfg.db}?charset={cfg.charset}"
+    uri = build_mysql_uri(
+        username=cfg.username,
+        password=cfg.password,
+        host=cfg.host,
+        port=cfg.port,
+        db=cfg.db,
+        charset=cfg.charset,
+    )
     return create_engine(uri).connect()
 
 
 def ping(engine: Connection) -> bool:
-    assert engine, "invalid engine"
+    if not engine:
+        raise ValueError("invalid engine")
     return not engine.closed

--- a/pypepper/helper/db/postgres.py
+++ b/pypepper/helper/db/postgres.py
@@ -7,6 +7,7 @@ from abc import ABCMeta
 from sqlalchemy import Connection, create_engine
 
 from pypepper.helper.db.interfaces import IConfig
+from pypepper.helper.db.uri import build_postgres_uri
 
 
 class Config(IConfig, metaclass=ABCMeta):
@@ -34,22 +35,33 @@ class Config(IConfig, metaclass=ABCMeta):
 
 
 def connect(cfg: Config) -> Connection:
-    assert cfg, "invalid database config"
+    if not cfg:
+        raise ValueError("invalid database config")
 
     if cfg.uri:
         return create_engine(cfg.uri).connect()
 
-    assert cfg.username, "invalid username"
-    assert cfg.password, "invalid password"
-    assert cfg.host, "invalid host"
-    assert cfg.db, "invalid db"
+    if not cfg.username:
+        raise ValueError("invalid username")
+    if not cfg.password:
+        raise ValueError("invalid password")
+    if not cfg.host:
+        raise ValueError("invalid host")
+    if not cfg.db:
+        raise ValueError("invalid db")
 
-    uri = f"postgresql+psycopg://{cfg.username}:{cfg.password}@{cfg.host}:{cfg.port}/{cfg.db}"
-    if cfg.sslmode:
-        uri = f"{uri}?sslmode={cfg.sslmode}"
+    uri = build_postgres_uri(
+        username=cfg.username,
+        password=cfg.password,
+        host=cfg.host,
+        port=cfg.port,
+        db=cfg.db,
+        sslmode=cfg.sslmode,
+    )
     return create_engine(uri).connect()
 
 
 def ping(engine: Connection) -> bool:
-    assert engine, "invalid engine"
+    if not engine:
+        raise ValueError("invalid engine")
     return not engine.closed

--- a/pypepper/helper/db/uri.py
+++ b/pypepper/helper/db/uri.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from urllib.parse import quote_plus
 
 
+def _quote_userinfo(username: str, password: str) -> tuple[str, str]:
+    return quote_plus(username), quote_plus(password)
+
+
 def build_postgres_uri(
     *,
     username: str,
@@ -15,11 +19,10 @@ def build_postgres_uri(
     sslmode: str | None = None,
 ) -> str:
     """Assemble a ``postgresql+psycopg`` URI with ``quote_plus`` on user/password."""
-    user = quote_plus(username)
-    pwd = quote_plus(password)
+    user, pwd = _quote_userinfo(username, password)
     uri = f"postgresql+psycopg://{user}:{pwd}@{host}:{port}/{db}"
     if sslmode:
-        uri = f"{uri}?sslmode={sslmode}"
+        return f"{uri}?sslmode={sslmode}"
     return uri
 
 
@@ -33,6 +36,5 @@ def build_mysql_uri(
     charset: str = "utf8mb4",
 ) -> str:
     """Assemble a ``mysql+pymysql`` URI with ``quote_plus`` on user/password."""
-    user = quote_plus(username)
-    pwd = quote_plus(password)
+    user, pwd = _quote_userinfo(username, password)
     return f"mysql+pymysql://{user}:{pwd}@{host}:{port}/{db}?charset={charset}"

--- a/pypepper/helper/db/uri.py
+++ b/pypepper/helper/db/uri.py
@@ -1,0 +1,38 @@
+"""Build SQLAlchemy database URIs with quoted credentials."""
+
+from __future__ import annotations
+
+from urllib.parse import quote_plus
+
+
+def build_postgres_uri(
+    *,
+    username: str,
+    password: str,
+    host: str,
+    port: int,
+    db: str,
+    sslmode: str | None = None,
+) -> str:
+    """Assemble a ``postgresql+psycopg`` URI with ``quote_plus`` on user/password."""
+    user = quote_plus(username)
+    pwd = quote_plus(password)
+    uri = f"postgresql+psycopg://{user}:{pwd}@{host}:{port}/{db}"
+    if sslmode:
+        uri = f"{uri}?sslmode={sslmode}"
+    return uri
+
+
+def build_mysql_uri(
+    *,
+    username: str,
+    password: str,
+    host: str,
+    port: int,
+    db: str,
+    charset: str = "utf8mb4",
+) -> str:
+    """Assemble a ``mysql+pymysql`` URI with ``quote_plus`` on user/password."""
+    user = quote_plus(username)
+    pwd = quote_plus(password)
+    return f"mysql+pymysql://{user}:{pwd}@{host}:{port}/{db}?charset={charset}"

--- a/pypepper/network/__init__.py
+++ b/pypepper/network/__init__.py
@@ -1,0 +1,7 @@
+"""HTTP and SSE networking."""
+
+from pypepper.network.http import server
+
+__all__ = [
+    "server",
+]

--- a/pypepper/network/http/__init__.py
+++ b/pypepper/network/http/__init__.py
@@ -1,0 +1,7 @@
+"""FastAPI HTTP server helpers."""
+
+from . import server
+
+__all__ = [
+    "server",
+]

--- a/pypepper/network/http/sse/__init__.py
+++ b/pypepper/network/http/sse/__init__.py
@@ -1,1 +1,11 @@
-"""SSE (Server-Sent Events) module for PyPepper"""
+"""SSE (Server-Sent Events) module for PyPepper."""
+
+from pypepper.network.http.sse.event import SSEEvent
+from pypepper.network.http.sse.security import require_sse_api_key
+from pypepper.network.http.sse.stream import sse_stream
+
+__all__ = [
+    "SSEEvent",
+    "require_sse_api_key",
+    "sse_stream",
+]

--- a/pypepper/network/http/sse/security.py
+++ b/pypepper/network/http/sse/security.py
@@ -10,6 +10,28 @@ from fastapi import HTTPException, Request, status
 
 from pypepper.common.cache import Cache
 from pypepper.common.config import config
+from pypepper.common.log import log
+
+_auth_disabled_warned = False
+
+
+def _warn_auth_disabled_once() -> None:
+    """Log once that auth-off accepts any non-empty key and is not a security boundary."""
+    global _auth_disabled_warned
+    if _auth_disabled_warned:
+        return
+    _auth_disabled_warned = True
+    log.warn(
+        "sse.authentication.enabled is false: any non-empty API key is accepted; "
+        "rate limiting buckets by presented key and is not a security boundary. "
+        "Enable authentication and inject validKeys for production."
+    )
+
+
+def reset_auth_disabled_warning() -> None:
+    """Reset the one-shot auth-off warning (tests)."""
+    global _auth_disabled_warned
+    _auth_disabled_warned = False
 
 
 class SSESecurityManager:
@@ -34,6 +56,7 @@ class SSESecurityManager:
         sse_config = config.get_yml_config().sse
         if not sse_config.authentication.enabled:
             # Authentication disabled, allow all non-empty keys
+            _warn_auth_disabled_once()
             return True
 
         valid_keys = list(sse_config.authentication.validKeys or [])

--- a/pypepper/network/http/sse/security.py
+++ b/pypepper/network/http/sse/security.py
@@ -13,14 +13,16 @@ from pypepper.common.config import config
 from pypepper.common.log import log
 
 _auth_disabled_warned = False
+_auth_disabled_warn_lock = Lock()
 
 
 def _warn_auth_disabled_once() -> None:
     """Log once that auth-off accepts any non-empty key and is not a security boundary."""
     global _auth_disabled_warned
-    if _auth_disabled_warned:
-        return
-    _auth_disabled_warned = True
+    with _auth_disabled_warn_lock:
+        if _auth_disabled_warned:
+            return
+        _auth_disabled_warned = True
     log.warn(
         "sse.authentication.enabled is false: any non-empty API key is accepted; "
         "rate limiting buckets by presented key and is not a security boundary. "
@@ -31,7 +33,8 @@ def _warn_auth_disabled_once() -> None:
 def reset_auth_disabled_warning() -> None:
     """Reset the one-shot auth-off warning (tests)."""
     global _auth_disabled_warned
-    _auth_disabled_warned = False
+    with _auth_disabled_warn_lock:
+        _auth_disabled_warned = False
 
 
 class SSESecurityManager:
@@ -52,10 +55,8 @@ class SSESecurityManager:
         if not api_key:
             return False
 
-        # Get valid API keys from config
         sse_config = config.get_yml_config().sse
         if not sse_config.authentication.enabled:
-            # Authentication disabled, allow all non-empty keys
             _warn_auth_disabled_once()
             return True
 

--- a/pypepper/scheduler/__init__.py
+++ b/pypepper/scheduler/__init__.py
@@ -1,0 +1,29 @@
+"""Scheduler domain: job pipeline and pluggable job store."""
+
+from . import events
+from .channel import Channel
+from .job import Job
+from .status import Status
+from .store import (
+    configure_job_store,
+    get_job_store,
+    reset_job_store,
+    setup_from_config,
+)
+from .task import Task
+from .worker import Worker
+from .workflow import Workflow
+
+__all__ = [
+    "Channel",
+    "Job",
+    "Status",
+    "Task",
+    "Worker",
+    "Workflow",
+    "configure_job_store",
+    "events",
+    "get_job_store",
+    "reset_job_store",
+    "setup_from_config",
+]

--- a/pypepper/scheduler/store/sql.py
+++ b/pypepper/scheduler/store/sql.py
@@ -10,6 +10,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.engine import Engine
 
 from pypepper.helper.db import mysql, postgres
+from pypepper.helper.db.uri import build_mysql_uri, build_postgres_uri
 from pypepper.scheduler.store.interfaces import IJobStore, JobRecord
 
 TABLE_NAME = "scheduler_jobs"
@@ -45,10 +46,16 @@ def _engine_from_config(backend: Literal["postgres", "mysql"], **kwargs: Any) ->
             return create_engine(cfg.uri)
         if not (cfg.username and cfg.password and cfg.host and cfg.db):
             raise ValueError("postgres job store requires uri=... or username, password, host, and db")
-        uri = f"postgresql+psycopg://{cfg.username}:{cfg.password}@{cfg.host}:{cfg.port}/{cfg.db}"
-        if cfg.sslmode:
-            uri = f"{uri}?sslmode={cfg.sslmode}"
-        return create_engine(uri)
+        return create_engine(
+            build_postgres_uri(
+                username=cfg.username,
+                password=cfg.password,
+                host=cfg.host,
+                port=cfg.port,
+                db=cfg.db,
+                sslmode=cfg.sslmode,
+            )
+        )
 
     mysql_cfg = mysql.Config(
         uri=kwargs.get("uri"),
@@ -63,11 +70,16 @@ def _engine_from_config(backend: Literal["postgres", "mysql"], **kwargs: Any) ->
         return create_engine(mysql_cfg.uri)
     if not (mysql_cfg.username and mysql_cfg.password and mysql_cfg.host and mysql_cfg.db):
         raise ValueError("mysql job store requires uri=... or username, password, host, and db")
-    uri = (
-        f"mysql+pymysql://{mysql_cfg.username}:{mysql_cfg.password}"
-        f"@{mysql_cfg.host}:{mysql_cfg.port}/{mysql_cfg.db}?charset={mysql_cfg.charset}"
+    return create_engine(
+        build_mysql_uri(
+            username=mysql_cfg.username,
+            password=mysql_cfg.password,
+            host=mysql_cfg.host,
+            port=mysql_cfg.port,
+            db=mysql_cfg.db,
+            charset=mysql_cfg.charset,
+        )
     )
-    return create_engine(uri)
 
 
 def _row_to_record(row: Any) -> JobRecord:

--- a/tests/helper/test_db_connect_validation.py
+++ b/tests/helper/test_db_connect_validation.py
@@ -3,6 +3,7 @@
 import pytest
 
 from pypepper.helper.db import mongodb, mysql, postgres
+from pypepper.helper.db.uri import build_mysql_uri, build_postgres_uri
 
 
 @pytest.mark.parametrize(
@@ -28,14 +29,68 @@ def test_postgres_connect_rejects_none_config():
         postgres.connect(None)  # type: ignore[arg-type]
 
 
+def test_mysql_connect_rejects_none_config():
+    with pytest.raises(ValueError, match="database config"):
+        mysql.connect(None)  # type: ignore[arg-type]
+
+
 def test_mysql_ping_rejects_none_engine():
     with pytest.raises(ValueError, match="engine"):
         mysql.ping(None)  # type: ignore[arg-type]
 
 
+def test_postgres_ping_rejects_none_engine():
+    with pytest.raises(ValueError, match="engine"):
+        postgres.ping(None)  # type: ignore[arg-type]
+
+
 def test_mongodb_connect_rejects_none_config():
     with pytest.raises(ValueError, match="database config"):
         mongodb.connect(None)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("mod", "builder", "kwargs"),
+    [
+        (
+            postgres,
+            build_postgres_uri,
+            {
+                "username": "u@x",
+                "password": "p#ass:w/ord",
+                "host": "localhost",
+                "port": 5432,
+                "db": "app",
+            },
+        ),
+        (
+            mysql,
+            build_mysql_uri,
+            {
+                "username": "u:ser",
+                "password": "p@ss/word",
+                "host": "127.0.0.1",
+                "port": 3306,
+                "db": "app",
+                "charset": "utf8mb4",
+            },
+        ),
+    ],
+)
+def test_connect_passes_quoted_uri_to_create_engine(monkeypatch, mod, builder, kwargs):
+    captured: list[str] = []
+
+    class _FakeEngine:
+        def connect(self):
+            return "conn"
+
+    def fake_create_engine(uri, *args, **kw):
+        captured.append(uri)
+        return _FakeEngine()
+
+    monkeypatch.setattr(mod, "create_engine", fake_create_engine)
+    assert mod.connect(mod.Config(**kwargs)) == "conn"
+    assert captured == [builder(**kwargs)]
 
 
 def test_public_reexports():
@@ -60,19 +115,20 @@ def test_public_reexports():
     assert callable(require_sse_api_key)
 
 
-def test_helper_valueerror_survives_optimize():
+@pytest.mark.parametrize("driver", ["postgres", "mysql"])
+def test_helper_valueerror_survives_optimize(driver: str):
     """Missing discrete fields must raise ValueError even under PYTHONOPTIMIZE."""
     import subprocess
     import sys
 
     code = (
-        "from pypepper.helper.db import postgres\n"
-        "try:\n"
-        "    postgres.connect(postgres.Config(username='u', password='p', host='h', db=None))\n"
-        "except ValueError as e:\n"
-        "    assert 'db' in str(e)\n"
-        "    raise SystemExit(0)\n"
-        "raise SystemExit('expected ValueError')\n"
+        f"from pypepper.helper.db import {driver}\n"
+        f"try:\n"
+        f"    {driver}.connect({driver}.Config(username='u', password='p', host='h', db=None))\n"
+        f"except ValueError as e:\n"
+        f"    assert 'db' in str(e)\n"
+        f"    raise SystemExit(0)\n"
+        f"raise SystemExit('expected ValueError')\n"
     )
     result = subprocess.run(
         [sys.executable, "-O", "-c", code],

--- a/tests/helper/test_db_connect_validation.py
+++ b/tests/helper/test_db_connect_validation.py
@@ -1,0 +1,84 @@
+"""Validation and -O safety for helper.db connectors."""
+
+import pytest
+
+from pypepper.helper.db import mongodb, mysql, postgres
+
+
+@pytest.mark.parametrize(
+    ("mod", "kwargs", "match"),
+    [
+        (postgres, {"username": None, "password": "p", "host": "h", "db": "d"}, "username"),
+        (postgres, {"username": "u", "password": None, "host": "h", "db": "d"}, "password"),
+        (postgres, {"username": "u", "password": "p", "host": None, "db": "d"}, "host"),
+        (postgres, {"username": "u", "password": "p", "host": "h", "db": None}, "db"),
+        (mysql, {"username": None, "password": "p", "host": "h", "db": "d"}, "username"),
+        (mysql, {"username": "u", "password": None, "host": "h", "db": "d"}, "password"),
+        (mysql, {"username": "u", "password": "p", "host": None, "db": "d"}, "host"),
+        (mysql, {"username": "u", "password": "p", "host": "h", "db": None}, "db"),
+    ],
+)
+def test_connect_raises_value_error_for_missing_fields(mod, kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        mod.connect(mod.Config(**kwargs))
+
+
+def test_postgres_connect_rejects_none_config():
+    with pytest.raises(ValueError, match="database config"):
+        postgres.connect(None)  # type: ignore[arg-type]
+
+
+def test_mysql_ping_rejects_none_engine():
+    with pytest.raises(ValueError, match="engine"):
+        mysql.ping(None)  # type: ignore[arg-type]
+
+
+def test_mongodb_connect_rejects_none_config():
+    with pytest.raises(ValueError, match="database config"):
+        mongodb.connect(None)  # type: ignore[arg-type]
+
+
+def test_public_reexports():
+    from pypepper.common.config import config
+    from pypepper.common.log import log
+    from pypepper.event import Event, new
+    from pypepper.fsm import FSM, State
+    from pypepper.helper import mysql as helper_mysql
+    from pypepper.network.http.sse import require_sse_api_key
+    from pypepper.scheduler import Job, Status, setup_from_config
+
+    assert config is not None
+    assert log is not None
+    assert Job is not None
+    assert Status.UNKNOWN.value == "Unknown"
+    assert callable(setup_from_config)
+    assert FSM is not None
+    assert State is not None
+    assert Event is not None
+    assert callable(new)
+    assert helper_mysql is not None
+    assert callable(require_sse_api_key)
+
+
+def test_helper_valueerror_survives_optimize():
+    """Missing discrete fields must raise ValueError even under PYTHONOPTIMIZE."""
+    import subprocess
+    import sys
+
+    code = (
+        "from pypepper.helper.db import postgres\n"
+        "try:\n"
+        "    postgres.connect(postgres.Config(username='u', password='p', host='h', db=None))\n"
+        "except ValueError as e:\n"
+        "    assert 'db' in str(e)\n"
+        "    raise SystemExit(0)\n"
+        "raise SystemExit('expected ValueError')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-O", "-c", code],
+        capture_output=True,
+        text=True,
+        cwd=".",
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout

--- a/tests/helper/test_db_uri.py
+++ b/tests/helper/test_db_uri.py
@@ -22,6 +22,22 @@ def test_build_postgres_uri_quotes_special_password():
     assert unquote_plus(parts.password or "") == "p@ss:w/ord"
 
 
+def test_build_postgres_uri_quotes_hash_and_plus():
+    uri = build_postgres_uri(
+        username="u+name",
+        password="a#b+c",
+        host="localhost",
+        port=5432,
+        db="app",
+    )
+    parts = urlsplit(uri)
+    assert parts.fragment == ""
+    assert unquote_plus(parts.username or "") == "u+name"
+    assert unquote_plus(parts.password or "") == "a#b+c"
+    assert "%23" in (parts.password or "")
+    assert "%2B" in (parts.username or "") or "%2B" in (parts.password or "")
+
+
 def test_build_postgres_uri_sslmode_query():
     uri = build_postgres_uri(
         username="u",
@@ -32,6 +48,17 @@ def test_build_postgres_uri_sslmode_query():
         sslmode="require",
     )
     assert uri.endswith("?sslmode=require")
+
+
+def test_build_postgres_uri_omits_query_without_sslmode():
+    uri = build_postgres_uri(
+        username="u",
+        password="p",
+        host="db.example",
+        port=5432,
+        db="app",
+    )
+    assert "?" not in uri
 
 
 def test_build_mysql_uri_quotes_special_password():

--- a/tests/helper/test_db_uri.py
+++ b/tests/helper/test_db_uri.py
@@ -1,0 +1,53 @@
+"""Unit tests for SQLAlchemy URI builders (credential quoting)."""
+
+from urllib.parse import unquote_plus, urlsplit
+
+from pypepper.helper.db.uri import build_mysql_uri, build_postgres_uri
+
+
+def test_build_postgres_uri_quotes_special_password():
+    uri = build_postgres_uri(
+        username="user@name",
+        password="p@ss:w/ord",
+        host="localhost",
+        port=5432,
+        db="app",
+    )
+    parts = urlsplit(uri)
+    assert parts.scheme == "postgresql+psycopg"
+    assert parts.hostname == "localhost"
+    assert parts.port == 5432
+    assert parts.path == "/app"
+    assert unquote_plus(parts.username or "") == "user@name"
+    assert unquote_plus(parts.password or "") == "p@ss:w/ord"
+
+
+def test_build_postgres_uri_sslmode_query():
+    uri = build_postgres_uri(
+        username="u",
+        password="p",
+        host="db.example",
+        port=5432,
+        db="app",
+        sslmode="require",
+    )
+    assert uri.endswith("?sslmode=require")
+
+
+def test_build_mysql_uri_quotes_special_password():
+    uri = build_mysql_uri(
+        username="u:ser",
+        password="p@ss/word",
+        host="127.0.0.1",
+        port=3306,
+        db="app",
+        charset="utf8mb4",
+    )
+    parts = urlsplit(uri)
+    assert parts.scheme == "mysql+pymysql"
+    assert parts.hostname == "127.0.0.1"
+    assert parts.port == 3306
+    assert parts.path == "/app"
+    assert "charset=utf8mb4" in (parts.query or "")
+    assert unquote_plus(parts.username or "") == "u:ser"
+    assert unquote_plus(parts.password or "") == "p@ss/word"

--- a/tests/network/http/sse/test_sse_security.py
+++ b/tests/network/http/sse/test_sse_security.py
@@ -43,7 +43,10 @@ def _mock_request(
 
 @pytest.fixture(autouse=True)
 def _reset_rate_limit_cache():
+    from pypepper.network.http.sse import security as sse_security
+
     SSESecurityManager._rate_limit_cache = Cache(maxsize=1000, ttl=60)
+    sse_security.reset_auth_disabled_warning()
 
 
 def test_validate_api_key_returns_false_for_empty_key(monkeypatch):
@@ -53,12 +56,23 @@ def test_validate_api_key_returns_false_for_empty_key(monkeypatch):
 
 
 def test_validate_api_key_allows_any_key_when_auth_disabled(monkeypatch):
+    from pypepper.common.log import log
+    from pypepper.network.http.sse import security as sse_security
+
+    warns: list[str] = []
+    monkeypatch.setattr(log, 'warn', lambda msg, *a, **k: warns.append(str(msg)))
     monkeypatch.setattr(
         config,
         'get_yml_config',
         lambda: _build_sse_config(auth_enabled=False),
     )
+    sse_security.reset_auth_disabled_warning()
     assert SSESecurityManager.validate_api_key('any-key') is True
+    assert any('authentication.enabled is false' in w for w in warns)
+    # Second call does not spam another warn.
+    warns.clear()
+    assert SSESecurityManager.validate_api_key('other-key') is True
+    assert warns == []
 
 
 def test_validate_api_key_checks_allow_list_when_auth_enabled(monkeypatch):

--- a/tests/network/http/sse/test_sse_security.py
+++ b/tests/network/http/sse/test_sse_security.py
@@ -55,6 +55,23 @@ def test_validate_api_key_returns_false_for_empty_key(monkeypatch):
     assert SSESecurityManager.validate_api_key('') is False
 
 
+def test_auth_disabled_empty_key_does_not_warn(monkeypatch):
+    from pypepper.common.log import log
+    from pypepper.network.http.sse import security as sse_security
+
+    warns: list[str] = []
+    monkeypatch.setattr(log, 'warn', lambda msg, *a, **k: warns.append(str(msg)))
+    monkeypatch.setattr(
+        config,
+        'get_yml_config',
+        lambda: _build_sse_config(auth_enabled=False),
+    )
+    sse_security.reset_auth_disabled_warning()
+    assert SSESecurityManager.validate_api_key(None) is False
+    assert SSESecurityManager.validate_api_key('') is False
+    assert warns == []
+
+
 def test_validate_api_key_allows_any_key_when_auth_disabled(monkeypatch):
     from pypepper.common.log import log
     from pypepper.network.http.sse import security as sse_security

--- a/tests/scheduler/test_sql_uri_quoting.py
+++ b/tests/scheduler/test_sql_uri_quoting.py
@@ -1,0 +1,65 @@
+"""Unit tests: SQL job store assembles quoted discrete URIs."""
+
+from urllib.parse import unquote_plus, urlsplit
+
+from pypepper.helper.db.uri import build_mysql_uri, build_postgres_uri
+from pypepper.scheduler.store import sql as sql_mod
+
+
+def test_engine_from_config_postgres_uses_quoted_uri(monkeypatch):
+    captured: list[str] = []
+
+    def fake_create_engine(uri, *args, **kwargs):
+        captured.append(uri)
+        return object()
+
+    monkeypatch.setattr(sql_mod, "create_engine", fake_create_engine)
+    sql_mod._engine_from_config(
+        "postgres",
+        username="user@name",
+        password="p#ass:w/ord",
+        host="localhost",
+        port=5432,
+        db="app",
+    )
+    assert len(captured) == 1
+    expected = build_postgres_uri(
+        username="user@name",
+        password="p#ass:w/ord",
+        host="localhost",
+        port=5432,
+        db="app",
+    )
+    assert captured[0] == expected
+    parts = urlsplit(captured[0])
+    assert parts.fragment == ""
+    assert unquote_plus(parts.password or "") == "p#ass:w/ord"
+
+
+def test_engine_from_config_mysql_uses_quoted_uri(monkeypatch):
+    captured: list[str] = []
+
+    def fake_create_engine(uri, *args, **kwargs):
+        captured.append(uri)
+        return object()
+
+    monkeypatch.setattr(sql_mod, "create_engine", fake_create_engine)
+    sql_mod._engine_from_config(
+        "mysql",
+        username="u:ser",
+        password="p@ss/word",
+        host="127.0.0.1",
+        port=3306,
+        db="app",
+        charset="utf8mb4",
+    )
+    assert captured == [
+        build_mysql_uri(
+            username="u:ser",
+            password="p@ss/word",
+            host="127.0.0.1",
+            port=3306,
+            db="app",
+            charset="utf8mb4",
+        )
+    ]


### PR DESCRIPTION
## Summary

- Problem: After P0, consumers still lacked curated imports; helper DB used `-O`-disabled `assert` and unquoted URI credentials; SSE auth-off / rate-limit footguns were undocumented; no SECURITY.md.
- Why it matters: Standing at ~9.2 needs DX discoverability, config hygiene, and honest security footgun handling without productizing CANCEL/heartbeat (P2).
- What changed: Domain `__init__` re-exports; helper `ValueError` + shared `quote_plus` URI builders; SSE auth-off one-shot warn + guide notes; `SECURITY.md`; Conf reserved annotations / jobStore field align; Getting Started refresh.
- What did NOT change (scope boundary): No auth-off rate-limit key algorithm change; no heartbeat/JSON-RPC wiring; no CANCEL; no publish.yml matrix.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] common
- [x] event
- [x] fsm
- [x] helper
- [x] network
- [x] scheduler
- [ ] CI/CD / infra

## Linked Issue/R

- Closes #
- Related #35 (P1 after P0 config/store decoupling; sixth-review roadmap)

## User-visible / Behavior Changes

- `from pypepper.scheduler import Job` (and other domain curated exports) work; `common.config` / `common.log` remain submodule imports to avoid shadowing.
- Helper DB incomplete config raises `ValueError` even under `python -O`; discrete SQL URIs quote user/password.
- SSE logs a one-shot warning when `authentication.enabled` is false; docs state rate limits are not a security boundary in that mode.
- New [`SECURITY.md`](SECURITY.md); README links to it.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes` — URI builders now `quote_plus` credentials when assembling discrete connection strings)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: Quoting prevents broken/misparsed URIs for passwords containing `@`/`:`/`/`; `uri=` passthrough still caller-owned.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local `.venv` + `devenv/ci.yaml`
- Relevant config (redacted): `conf/app.config.yaml`

### Steps

1. `docker compose -f devenv/ci.yaml up -d`
2. `PATH=".venv/bin:$PATH" make check && make test && make docs`
3. `python -c "from pypepper.scheduler import Job"`

### Expected

- Checks/docs green; 192+ tests; curated import works; `-O` helper missing-field still `ValueError`

### Actual

- `make check` / `make test` (192 passed, ~92.9% cov) / `make docs` passed locally

## Evidence

- [x] Trace/log snippets — local make check/test/docs

## Human Verification (required)

- Verified scenarios: curated imports; helper validation + URI quote unit tests; SSE auth-off warn once; docs build
- Edge cases checked: `common.config` submodule import not shadowed; password chars `@:`/`/`
- What you did **not** verify: GitHub Actions on this PR before review; live DB connect with special-char password

## Compatibility / Migration

- Backward compatible? (`Yes` for existing deep imports)
- Config/env changes? (`No` required; ConfSchedulerJobStore type docs now include sslmode/charset/auth_source)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR
- Files/config to restore: domain `__init__.py`, helper/db, sse/security.py, SECURITY.md
- Known bad symptoms reviewers should watch for: import cycles from package `__init__`; unexpected SSE warn in auth-off test envs

## Risks and Mitigations

- Risk: Package-level re-exports increase import surface / cycle risk
  - Mitigation: curated `__all__` only; relative imports; `common` kept submodule-only for config/log
- Risk: Operators ignore auth-off warn
  - Mitigation: guide Security notes + SECURITY.md non-vulnerability clarification

## Test plan

- [x] `make check` + `make test` with devenv
- [x] `make docs`
- [ ] CI green on this PR