### PR TITLE
feat(scheduler): job cancel, FSM restore, drop ghost config

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,71 @@ permissions:
   id-token: write
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    name: Lint and docs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Use python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install
+        run: python -m pip install -r requirements-dev.txt ; python -m pip install -r requirements.txt
+
+      - name: Lint
+        run: make lint
+
+      - name: Mutable class attribute check
+        run: python ./scripts/check_mutable_class_attrs.py
+
+      - name: Docs
+        run: make docs
+
+  pretest:
+    needs: lint
+    runs-on: ubuntu-latest
+    name: Pre-publish tests (Python 3.13)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Use python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install
+        run: python -m pip install -r requirements-dev.txt ; python -m pip install -r requirements.txt
+
+      - name: Start devenv
+        run: |
+          docker compose -f ./devenv/ci.yaml up -d --wait || (
+            echo "compose --wait unsupported, falling back to health poll"
+            docker compose -f ./devenv/ci.yaml up -d
+            for i in 1 2 3 4 5 6 7 8 9 10; do
+              docker compose -f ./devenv/ci.yaml ps | grep -q healthy && break
+              sleep 3
+            done
+          )
+          docker compose -f ./devenv/ci.yaml ps
+
+      - name: Mutable class attribute check
+        run: python ./scripts/check_mutable_class_attrs.py
+
+      - name: Test with coverage
+        run: pytest --cov=pypepper --cov-report=term --cov-fail-under=90 tests/
+
+      - name: Stop devenv
+        if: always()
+        run: docker compose -f ./devenv/ci.yaml down
+
   publish:
     name: Build and publish
+    needs: pretest
     runs-on: ubuntu-latest
     environment: pypi
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,7 @@ jobs:
     environment: pypi
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Use python 3.13
         uses: actions/setup-python@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,8 @@ Job snapshots (`JobRecord`) are metadata-only (workflows/executors are not seria
 |-------|-----------------|-------------------|
 | Pre-execution (`INIT`/`SCHEDULE` in `dispatch`) | `INIT`/`SCHEDULE`/`save()` fails before enqueue | **Roll back** FSM/`Job.status` so `scheduled()` can retry |
 | Pre-execution (channel enqueue) | Enqueue fails before job lands on channel | **Roll back** FSM/`Job.status`, best-effort **delete** Scheduled row, re-raise. Ghost may remain if delete fails. After successful `send`, do **not** roll back (exception still means the job may run). |
-| Start (`RUN`) | Running snapshot fails | Do **not** run workflows; prefer persist `Failed`, else restore pre-`RUN` |
+| Start (`RUN`) | Running snapshot fails | Do **not** run workflows; prefer persist `Failed`. If that also fails and FSM is already `Cancelled`, keep Cancelled and retry `save()` only — do **not** restore pre-`RUN`. Otherwise restore pre-`RUN` |
+| Cancel (`Job.cancel()`) | Cancel snapshot fails | **Keep** Cancelled FSM; retry `job.save()` only. Worker does not apply `CANCEL`; on cancel exits it retries Cancelled persist if the store lags |
 | Terminal success (`COMPLETE`) | Work already finished | **Keep** Completed FSM; retry `job.save()` only — **never** re-run workflows because the terminal write failed |
 | Terminal failure (`FAIL`) | Work already failed | **Keep** Failed FSM; retry `job.save()` only |
 | `Job.save()` field updates | `put()` raises | Do **not** mutate in-memory `status`/`updated` until `put` succeeds |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 
 ### Changed
 - Scheduler `CANCEL` FSM transition accepts Scheduled and InProgress.
-- Docs: architecture config table matches live keys; scheduler guide documents cancel + unused Task fields remain class attributes (not wired).
+- Worker retries Cancelled persist on cancel exits and does not restore pre-RUN over a winning cancel; cancel persist failures are surfaced.
+- Docs: architecture config table drops ghost keys; scheduler guide separates Worker COMPLETE/FAIL vs `Job.cancel()` persist rules.
 
 ## 0.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### Changed
 - Scheduler `CANCEL` FSM transition accepts Scheduled and InProgress.
 - Worker retries Cancelled persist on cancel exits and does not restore pre-RUN over a winning cancel; cancel persist failures are surfaced.
-- Docs: architecture config table drops ghost keys; scheduler guide separates Worker COMPLETE/FAIL vs `Job.cancel()` persist rules.
+- Docs: architecture config table drops ghost keys; scheduler guide / CLAUDE / AGENTS Start(`RUN`) note cancel-won skip-restore; Cancel persist rules separated from Worker COMPLETE/FAIL.
 
 ## 0.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Added
+- Public `FSM.restore(state)` for lifecycle rollback; `Job.restore_lifecycle` uses it (no `_fsm._current` writes).
+- `Job.cancel()` for Scheduled/InProgress jobs; Worker skips cancelled jobs and does not COMPLETE after cancel at workflow boundaries.
+- Scheduler E2E example (`example/scheduler/app.py`).
+- Tag publish workflow runs lint + pytest before PyPI upload.
+
+### Removed
+- Unused ghost config types/keys: `cluster`, `heartbeat`, `network.jsonRPCProxy`, HTTP(S) `timeout`, `log.mode`, `sse.enabled`, `sse.heartbeatIntervalSeconds`.
+
+### Changed
+- Scheduler `CANCEL` FSM transition accepts Scheduled and InProgress.
+- Docs: architecture config table matches live keys; scheduler guide documents cancel + unused Task fields remain class attributes (not wired).
+
 ## 0.6.1
 
 ### Added

--- a/conf/app.config.yaml
+++ b/conf/app.config.yaml
@@ -1,9 +1,3 @@
-# Cluster settings (loaded; unused by runtime servers — reserved metadata)
-cluster:
-  name: cluster-name
-  id: 5dd31f84-5df2-48c7-b84b-32d25b17a930
-  description: 'cluster description'
-
 # Network settings
 network:
   ip: 0.0.0.0
@@ -40,8 +34,6 @@ log:
 
 # SSE (Server-Sent Events) settings
 sse:
-  enabled: true
-
   # Connection limits (for 100 concurrent users)
   maxTotalConnections: 100
   maxConnectionsPerIP: 5
@@ -49,9 +41,8 @@ sse:
   # Queue configuration
   maxQueueSize: 500
 
-  # Timeout configuration
+  # Timeout configuration (drives SSE ping wait)
   streamTimeoutSeconds: 30
-  heartbeatIntervalSeconds: 15
 
   # API Key authentication
   authentication:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,15 +85,10 @@ Runtime YAML lives in `conf/app.config.yaml`. Models vs runtime:
 | Area | Status |
 |------|--------|
 | `network.httpServer` / `httpsServer` (`enable`, `port`, TLS files) | Live |
-| `network.*.timeout` | Reserved (servers hardcode keep-alive timeout) |
 | `log.level` / `log.colorize` | Live |
-| `log.mode` | Reserved |
 | `sse` auth, rate limit, connection caps, `streamTimeoutSeconds`, `maxQueueSize` | Live (read at request/stream time) |
-| `sse.enabled`, `sse.heartbeatIntervalSeconds` | Reserved (loaded; not applied by runtime) |
 | `tracing.*` | Live via `load_config` → tracing `setup_from_config` |
 | `scheduler.jobStore` | Live only after explicit `scheduler.store.setup_from_config` (not `load_config`) |
-| `cluster` | Loaded but unused by runtime |
-| `heartbeat`, `network.jsonRPCProxy` | Reserved (not wired yet) |
 | `custom` | App-defined |
 
 ## Observability

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -57,6 +57,15 @@ python example/server/app.py --config ./conf/app.config.yaml
 Default HTTP port comes from `conf/app.config.yaml` (`network.httpServer.port`, typically `55550`).
 The example calls `setup_from_config` after `load_config`.
 
+### Scheduler example
+
+```shell
+python example/scheduler/app.py
+```
+
+Runs `load_config` → `setup_from_config` → `Job.scheduled` → `Worker` through COMPLETE.
+See [Scheduler](guides/scheduler.md).
+
 ### SSE example
 
 Inject a local API key (config ships with empty `validKeys`):

--- a/docs/guides/release.md
+++ b/docs/guides/release.md
@@ -36,7 +36,7 @@ git push origin vX.Y.Z
 
 Example: if `pyproject.toml` has `version = "0.6.1"`, the tag must be `v0.6.1`.
 
-4. Watch **Actions → Publish to PyPI**. A mismatch between tag and `pyproject.toml` fails the job before upload.
+4. Watch **Actions → Publish to PyPI**. The workflow runs lint + tests first; a failing pretest or a tag/`pyproject.toml` version mismatch blocks upload.
 5. Confirm the version on [https://pypi.org/project/pypepper/](https://pypi.org/project/pypepper/).
 
 ## Manual fallback

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -145,7 +145,7 @@ Connections reuse [`helper.db`](helper-db.md) settings style (`uri` or discrete 
 
 - **Schedule** (`INIT`/`SCHEDULE` + `save` in `dispatch`): roll back FSM and `Job.status` so `scheduled()` can retry (no store delete needed if `save` never succeeded).
 - **Enqueue** (channel/processor setup or send rejected): roll back FSM/`Job.status` and best-effort delete the Scheduled store row. If delete fails, a Scheduled row may remain (ghost). After the job is successfully sent to the channel, do **not** roll back — a raised error then is a committed enqueue plus secondary failure (the job may still run); do not treat it as “nothing queued.”
-- **Start (`RUN`)**: if Running snapshot fails, do not run workflows; prefer persist `Failed`, else restore pre-RUN.
+- **Start (`RUN`)**: if Running snapshot fails, do not run workflows; prefer persist `Failed`. If that also fails and the job is already `Cancelled`, keep Cancelled and retry `job.save()` only — do **not** restore pre-RUN over a winning cancel. Otherwise restore pre-RUN.
 - **After work** (COMPLETE/FAIL via Worker): keep the terminal FSM; retry `job.save()` only — do not re-run workflows because the snapshot write failed.
 - **Cancel** (`Job.cancel()`): apply `CANCEL` then `save()`; on persist failure keep Cancelled in the FSM and retry `job.save()` only. The Worker does not apply `CANCEL` — it skips or exits when the job is already cancelled (and retries Cancelled persist if the store lags).
 - `Job.save()` updates in-memory `status`/`updated` only after the store `put` succeeds.

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -4,6 +4,9 @@ Workflow-based job pipeline: **Task → Workflow → Job → Channel → Worker*
 
 ## Minimal path
 
+See the runnable example [`example/scheduler/app.py`](https://github.com/jovijovi/pypepper/blob/main/example/scheduler/app.py)
+(`load_config` → `setup_from_config` → `Job.scheduled` → `Worker` → COMPLETE).
+
 ```python
 import asyncio
 
@@ -55,7 +58,12 @@ Each `Job` owns an FSM from `build_scheduler_fsm()`:
 | `RUN` | → in progress |
 | `COMPLETE` | → completed |
 | `FAIL` | → failed |
-| `CANCEL` | → cancelled |
+| `CANCEL` | scheduled or in progress → cancelled |
+
+`Job.cancel()` applies `CANCEL` and persists. Cancellation is cooperative: the Worker
+skips work if the job is already cancelled, and stops before `COMPLETE` at workflow
+boundaries. It does **not** interrupt a sync workflow mid-`to_thread`. `Channel.stop`
+only stops the consumer loop; it is not job cancel.
 
 ## Workflow retries
 
@@ -126,7 +134,8 @@ scheduler:
 ```
 
 Connections reuse [`helper.db`](helper-db.md) settings style (`uri` or discrete host/user/password/db).
-`Worker` also calls `save()` after `RUN` / `COMPLETE` / `FAIL`.
+`Worker` also calls `save()` after `RUN` / `COMPLETE` / `FAIL` (and skips terminal
+`COMPLETE` when the job is already `Cancelled`). `Job.cancel()` persists `Cancelled`.
 
 `Job.scheduled()` / `Processor.run` must be called from a **sync** context. They raise
 `RuntimeError` if an event loop is already running. From async code: apply `INIT` then
@@ -137,7 +146,7 @@ Connections reuse [`helper.db`](helper-db.md) settings style (`uri` or discrete 
 - **Schedule** (`INIT`/`SCHEDULE` + `save` in `dispatch`): roll back FSM and `Job.status` so `scheduled()` can retry (no store delete needed if `save` never succeeded).
 - **Enqueue** (channel/processor setup or send rejected): roll back FSM/`Job.status` and best-effort delete the Scheduled store row. If delete fails, a Scheduled row may remain (ghost). After the job is successfully sent to the channel, do **not** roll back — a raised error then is a committed enqueue plus secondary failure (the job may still run); do not treat it as “nothing queued.”
 - **Start (`RUN`)**: if Running snapshot fails, do not run workflows; prefer persist `Failed`, else restore pre-RUN.
-- **After work** (COMPLETE/FAIL): keep the terminal FSM; retry `job.save()` only — do not re-run workflows because the snapshot write failed.
+- **After work** (COMPLETE/FAIL/CANCEL): keep the terminal FSM; retry `job.save()` only — do not re-run workflows because the snapshot write failed.
 - `Job.save()` updates in-memory `status`/`updated` only after the store `put` succeeds.
 - `Job.to_record()` reports FSM status (authoritative), which may lead last durable store status and in-memory `Job.status` when a terminal persist fails.
 - `IJobStore.put` upserts by `id` and must not overwrite an existing row's `created`.

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -146,7 +146,8 @@ Connections reuse [`helper.db`](helper-db.md) settings style (`uri` or discrete 
 - **Schedule** (`INIT`/`SCHEDULE` + `save` in `dispatch`): roll back FSM and `Job.status` so `scheduled()` can retry (no store delete needed if `save` never succeeded).
 - **Enqueue** (channel/processor setup or send rejected): roll back FSM/`Job.status` and best-effort delete the Scheduled store row. If delete fails, a Scheduled row may remain (ghost). After the job is successfully sent to the channel, do **not** roll back — a raised error then is a committed enqueue plus secondary failure (the job may still run); do not treat it as “nothing queued.”
 - **Start (`RUN`)**: if Running snapshot fails, do not run workflows; prefer persist `Failed`, else restore pre-RUN.
-- **After work** (COMPLETE/FAIL/CANCEL): keep the terminal FSM; retry `job.save()` only — do not re-run workflows because the snapshot write failed.
+- **After work** (COMPLETE/FAIL via Worker): keep the terminal FSM; retry `job.save()` only — do not re-run workflows because the snapshot write failed.
+- **Cancel** (`Job.cancel()`): apply `CANCEL` then `save()`; on persist failure keep Cancelled in the FSM and retry `job.save()` only. The Worker does not apply `CANCEL` — it skips or exits when the job is already cancelled (and retries Cancelled persist if the store lags).
 - `Job.save()` updates in-memory `status`/`updated` only after the store `put` succeeds.
 - `Job.to_record()` reports FSM status (authoritative), which may lead last durable store status and in-memory `Job.status` when a terminal persist fails.
 - `IJobStore.put` upserts by `id` and must not overwrite an existing row's `created`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ Published docs: <https://jovijovi.github.io/pypepper/>
 ## Examples
 
 - `example/server/app.py` — minimal HTTP handlers
+- `example/scheduler/app.py` — Job → Worker through COMPLETE
 - `example/sse/app.py` — SSE with API key auth and rate limiting
 
 ```shell

--- a/example/scheduler/app.py
+++ b/example/scheduler/app.py
@@ -1,0 +1,80 @@
+"""
+Scheduler end-to-end example: config → job store → Job.scheduled → Worker → COMPLETE.
+
+Usage (from repo root):
+
+    python example/scheduler/app.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from pypepper.common.config import config
+from pypepper.common.log import log
+from pypepper.logo import logo
+from pypepper.scheduler.channel import manager
+from pypepper.scheduler.executor import CallableExecutor
+from pypepper.scheduler.job import Job
+from pypepper.scheduler.status import Status
+from pypepper.scheduler.store import setup_from_config
+from pypepper.scheduler.task import Task
+from pypepper.scheduler.worker import Worker
+from pypepper.scheduler.workflow import Workflow
+
+CHANNEL_ID = "example-scheduler"
+
+
+def work(task, context):
+    log.info(f"running task={task.name}")
+    return {"ok": True, "task": task.name}
+
+
+def build_job() -> Job:
+    workflow = Workflow()
+    workflow.add_task(
+        Task(
+            channel_id=CHANNEL_ID,
+            dag_id="dag-1",
+            fingerprint="fp-1",
+            name="step-1",
+            category="demo",
+            description="scheduler e2e step",
+            tags=["example"],
+            executor=CallableExecutor(work),
+            retry_count=0,
+            retry_delay=0,
+            optional=False,
+        )
+    )
+    job = Job(category="demo", channel_id=CHANNEL_ID)
+    job.workflows.append(workflow)
+    return job
+
+
+async def run_worker(job: Job) -> None:
+    worker = Worker(manager.available(CHANNEL_ID))
+    processed = await worker.run_once()
+    assert processed is job
+    assert job._fsm.current().value == Status.COMPLETED
+    saved = Job.get_saved(job.id)
+    assert saved is not None
+    assert saved.status == Status.COMPLETED.value
+    log.info(f"job completed: id={job.id} status={saved.status}")
+
+
+def main() -> None:
+    log.logo(logo)
+    config.load_config("./conf/app.config.yaml")
+    setup_from_config(config.get_yml_config())
+
+    # Job.scheduled() must run in a sync context (no running event loop).
+    job = build_job()
+    job.scheduled()
+    log.info(f"job scheduled: id={job.id} status={job.status}")
+
+    asyncio.run(run_worker(job))
+
+
+if __name__ == "__main__":
+    main()

--- a/example/scheduler/app.py
+++ b/example/scheduler/app.py
@@ -42,9 +42,6 @@ def build_job() -> Job:
             description="scheduler e2e step",
             tags=["example"],
             executor=CallableExecutor(work),
-            retry_count=0,
-            retry_delay=0,
-            optional=False,
         )
     )
     job = Job(category="demo", channel_id=CHANNEL_ID)
@@ -56,7 +53,7 @@ async def run_worker(job: Job) -> None:
     worker = Worker(manager.available(CHANNEL_ID))
     processed = await worker.run_once()
     assert processed is job
-    assert job._fsm.current().value == Status.COMPLETED
+    assert job.status == Status.COMPLETED.value
     saved = Job.get_saved(job.id)
     assert saved is not None
     assert saved.status == Status.COMPLETED.value

--- a/example/sse/app.py
+++ b/example/sse/app.py
@@ -185,7 +185,6 @@ def main():
 
     # Log SSE configuration
     sse_config = config.get_yml_config().sse
-    log.info(f"SSE enabled: {sse_config.enabled}")
     log.info(f"Max connections: {sse_config.maxTotalConnections}")
     log.info(f"Authentication: {sse_config.authentication.enabled}")
     if not demo_key and sse_config.authentication.enabled:

--- a/pypepper/common/config.py
+++ b/pypepper/common/config.py
@@ -10,58 +10,27 @@ from box import Box
 from pypepper.common.log import log
 
 
-class ConfCluster:
-    """Loaded from YAML ``cluster``; currently unused by runtime servers (reserved)."""
-
-    name: str
-    id: str
-    description: str
-
-
 class ConfHTTPServer:
     enable: bool
     port: int
-    # Reserved: HTTP server currently hardcodes keep-alive timeout.
-    timeout: int = 30
 
 
 class ConfHTTPSServer:
     enable: bool
     port: int
     mutualTLS: bool
-    # Reserved: HTTPS server currently hardcodes keep-alive timeout.
-    timeout: int = 30
     certFile: str = ""
     keyFile: str = ""
     caFile: str = ""
-
-
-class ConfHeartbeat:
-    """Reserved: not wired to a heartbeat server yet."""
-
-    enable: bool
-    port: int
-    logger: bool
-
-
-class ConfJsonRPCProxy:
-    """Reserved: not wired to a JSON-RPC proxy yet."""
-
-    enable: bool
-    port: int
-    mutualTLS: bool
 
 
 class ConfNetwork:
     ip: str
     httpServer: ConfHTTPServer
     httpsServer: ConfHTTPSServer
-    jsonRPCProxy: ConfJsonRPCProxy
 
 
 class ConfLog:
-    # Reserved: only ``level`` and ``colorize`` are applied by load_config.
-    mode: str
     level: str
     colorize: bool
 
@@ -77,12 +46,10 @@ class ConfSSERateLimit:
 
 
 class ConfSSE:
-    enabled: bool
     maxTotalConnections: int
     maxConnectionsPerIP: int
     maxQueueSize: int
     streamTimeoutSeconds: int
-    heartbeatIntervalSeconds: int
     authentication: ConfSSEAuthentication
     rateLimit: ConfSSERateLimit
 
@@ -117,9 +84,7 @@ class ConfScheduler:
 
 
 class YmlConfig:
-    cluster: ConfCluster
     network: ConfNetwork
-    heartbeat: ConfHeartbeat
     log: ConfLog
     sse: ConfSSE
     tracing: ConfTracing

--- a/pypepper/fsm/fsm.py
+++ b/pypepper/fsm/fsm.py
@@ -213,6 +213,10 @@ class FSM(IFSM):
 
         return self._current
 
+    def restore(self, state: IState | None) -> None:
+        """Restore current state without running a transition (rollback helper)."""
+        self._current = state
+
     def on(
         self,
         event: IEvent,

--- a/pypepper/fsm/interfaces.py
+++ b/pypepper/fsm/interfaces.py
@@ -44,6 +44,10 @@ class IFSM(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def restore(self, state: IState | None) -> None:
+        """Restore current state without running a transition (rollback helper)."""
+
+    @abstractmethod
     def on(
         self,
         event: IEvent,

--- a/pypepper/scheduler/events.py
+++ b/pypepper/scheduler/events.py
@@ -44,7 +44,7 @@ _OPTIONS = fsm.Options(
         ),
         fsm.Transition(
             event=CANCEL,
-            from_state=[fsm.State(Status.IN_PROGRESS)],
+            from_state=[fsm.State(Status.SCHEDULED), fsm.State(Status.IN_PROGRESS)],
             to_state=fsm.State(Status.CANCELLED),
         ),
     ],

--- a/pypepper/scheduler/events.py
+++ b/pypepper/scheduler/events.py
@@ -11,6 +11,8 @@ SCHEDULE = event.new(name="schedule", src=Status.INITIALIZING)
 RUN = event.new(name="run", src=Status.SCHEDULED)
 FAIL = event.new(name="fail", src=Status.IN_PROGRESS)
 COMPLETE = event.new(name="complete", src=Status.IN_PROGRESS)
+# Event.src is descriptive metadata only; transition from_state is authoritative
+# (Scheduled and InProgress both allowed — see CANCEL Transition below).
 CANCEL = event.new(name="cancel", src=Status.IN_PROGRESS)
 
 _OPTIONS = fsm.Options(

--- a/pypepper/scheduler/job.py
+++ b/pypepper/scheduler/job.py
@@ -194,13 +194,18 @@ class Job(IJob):
 
     def restore_lifecycle(self, state: IState | None, status: str) -> None:
         """Restore FSM/`status` after schedule/enqueue failure or RUN-start persist failure."""
-        self._fsm._current = state
+        self._fsm.restore(state)
         self.status = status
 
     def apply_event(self, event: IEvent) -> None:
         """Apply an FSM event or raise if the transition is invalid."""
         resp = self._fsm.on(event)
         _raise_if_transition_failed(resp.error)
+
+    def cancel(self) -> None:
+        """Cancel a Scheduled or InProgress job and persist Cancelled."""
+        self.apply_event(events.CANCEL)
+        self.save()
 
     def to_record(self) -> JobRecord:
         """Authoritative lifecycle snapshot from the FSM (may lead durable ``status``)."""

--- a/pypepper/scheduler/job.py
+++ b/pypepper/scheduler/job.py
@@ -168,6 +168,14 @@ class IJob(IBase, metaclass=ABCMeta):
     def scheduled(self) -> None:
         pass
 
+    @abstractmethod
+    def cancel(self) -> None:
+        pass
+
+    @abstractmethod
+    def is_cancelled(self) -> bool:
+        pass
+
 
 class Job(IJob):
     def __init__(self, category: str | None = None, channel_id: str = "default") -> None:
@@ -192,6 +200,9 @@ class Job(IJob):
             return value.value
         return str(value)
 
+    def is_cancelled(self) -> bool:
+        return self._current_status() == Status.CANCELLED.value
+
     def restore_lifecycle(self, state: IState | None, status: str) -> None:
         """Restore FSM/`status` after schedule/enqueue failure or RUN-start persist failure."""
         self._fsm.restore(state)
@@ -203,7 +214,11 @@ class Job(IJob):
         _raise_if_transition_failed(resp.error)
 
     def cancel(self) -> None:
-        """Cancel a Scheduled or InProgress job and persist Cancelled."""
+        """
+        Cancel a Scheduled or InProgress job and persist Cancelled.
+
+        On ``save()`` failure the FSM stays Cancelled; retry ``job.save()`` only.
+        """
         self.apply_event(events.CANCEL)
         self.save()
 

--- a/pypepper/scheduler/worker.py
+++ b/pypepper/scheduler/worker.py
@@ -34,6 +34,17 @@ def _ensure_cancelled_persisted(job: Job) -> None:
     job.save()
 
 
+def _ensure_cancelled_persisted_logged(job: Job, *, cause: BaseException | None = None) -> None:
+    """Like ``_ensure_cancelled_persisted``, with operator log on persist failure."""
+    try:
+        _ensure_cancelled_persisted(job)
+    except Exception as save_exc:
+        log.error(f"Job cancelled but Cancelled persist failed: id={job.id}; retry job.save only: {save_exc}")
+        if cause is not None:
+            raise save_exc from cause
+        raise
+
+
 class Worker:
     """Consume jobs from a channel and run their workflows."""
 
@@ -55,7 +66,7 @@ class Worker:
     async def _process(self, job: Job) -> None:
         if job.is_cancelled():
             log.info(f"Job already cancelled, skip: id={job.id}")
-            _ensure_cancelled_persisted(job)
+            _ensure_cancelled_persisted_logged(job)
             return
 
         prev_state = job._fsm.current()
@@ -78,7 +89,7 @@ class Worker:
                             f"Job RUN persist failed: id={job.id}, error={save_exc}; "
                             f"cancel won but Cancelled persist failed: {cancel_save_exc}"
                         )
-                        raise save_exc from cancel_save_exc
+                        raise cancel_save_exc from save_exc
                     log.error(
                         f"Job RUN persist failed: id={job.id}, error={save_exc}; "
                         f"cancel already applied (skip restore): {fail_save_exc}"
@@ -100,20 +111,14 @@ class Worker:
             for workflow in workflows:
                 if job.is_cancelled():
                     log.info(f"Job cancelled between workflows: id={job.id}")
-                    _ensure_cancelled_persisted(job)
+                    _ensure_cancelled_persisted_logged(job)
                     return
                 # Workflow.run is sync; run it in a worker thread.
                 await asyncio.to_thread(workflow.run)
         except Exception as e:
             if job.is_cancelled():
                 log.info(f"Job cancelled (workflow error ignored): id={job.id}, error={e}")
-                try:
-                    _ensure_cancelled_persisted(job)
-                except Exception as save_exc:
-                    log.error(
-                        f"Job cancelled but Cancelled persist failed: id={job.id}; retry job.save only: {save_exc}"
-                    )
-                    raise save_exc from e
+                _ensure_cancelled_persisted_logged(job, cause=e)
                 return
             try:
                 _transition_and_save_terminal(job, events.FAIL)
@@ -128,7 +133,7 @@ class Worker:
 
         if job.is_cancelled():
             log.info(f"Job cancelled before complete: id={job.id}")
-            _ensure_cancelled_persisted(job)
+            _ensure_cancelled_persisted_logged(job)
             return
 
         try:

--- a/pypepper/scheduler/worker.py
+++ b/pypepper/scheduler/worker.py
@@ -10,18 +10,23 @@ from pypepper.event.interfaces import IEvent
 from pypepper.scheduler import events
 from pypepper.scheduler.channel import Channel
 from pypepper.scheduler.job import Job
+from pypepper.scheduler.status import Status
 
 
 def _transition_and_save_terminal(job: Job, event: IEvent) -> None:
     """
-    Apply a terminal FSM event (COMPLETE / FAIL) then persist.
+    Apply a terminal FSM event (COMPLETE / FAIL / CANCEL) then persist.
 
-    Work (or failure) has already happened: keep the terminal FSM state even if
-    persistence fails. Callers should retry ``job.save()`` only — never re-run
-    workflows solely because the terminal snapshot write failed.
+    Work (or failure / cancel) has already happened: keep the terminal FSM state
+    even if persistence fails. Callers should retry ``job.save()`` only — never
+    re-run workflows solely because the terminal snapshot write failed.
     """
     job.apply_event(event)
     job.save()
+
+
+def _is_cancelled(job: Job) -> bool:
+    return job._current_status() == Status.CANCELLED.value
 
 
 class Worker:
@@ -43,6 +48,10 @@ class Worker:
             await self.run_once()
 
     async def _process(self, job: Job) -> None:
+        if _is_cancelled(job):
+            log.info(f"Job already cancelled, skip: id={job.id}")
+            return
+
         prev_state = job._fsm.current()
         prev_status = job.status
         job.apply_event(events.RUN)
@@ -68,9 +77,15 @@ class Worker:
         try:
             workflows = getattr(job, "workflows", None) or []
             for workflow in workflows:
+                if _is_cancelled(job):
+                    log.info(f"Job cancelled during work: id={job.id}")
+                    return
                 # Workflow.run is sync; run it in a worker thread.
                 await asyncio.to_thread(workflow.run)
         except Exception as e:
+            if _is_cancelled(job):
+                log.info(f"Job cancelled (after workflow error ignored): id={job.id}")
+                return
             try:
                 _transition_and_save_terminal(job, events.FAIL)
             except Exception as save_exc:
@@ -81,6 +96,10 @@ class Worker:
                 raise e from save_exc
             log.error(f"Job failed: id={job.id}, error={e}")
             raise
+
+        if _is_cancelled(job):
+            log.info(f"Job cancelled before complete: id={job.id}")
+            return
 
         try:
             _transition_and_save_terminal(job, events.COMPLETE)

--- a/pypepper/scheduler/worker.py
+++ b/pypepper/scheduler/worker.py
@@ -15,18 +15,23 @@ from pypepper.scheduler.status import Status
 
 def _transition_and_save_terminal(job: Job, event: IEvent) -> None:
     """
-    Apply a terminal FSM event (COMPLETE / FAIL / CANCEL) then persist.
+    Apply a terminal FSM event (COMPLETE / FAIL) then persist.
 
-    Work (or failure / cancel) has already happened: keep the terminal FSM state
-    even if persistence fails. Callers should retry ``job.save()`` only — never
-    re-run workflows solely because the terminal snapshot write failed.
+    Cancel is applied by ``Job.cancel()``, not here. Work (or failure) has already
+    happened: keep the terminal FSM state even if persistence fails. Callers should
+    retry ``job.save()`` only — never re-run workflows solely because the terminal
+    snapshot write failed.
     """
     job.apply_event(event)
     job.save()
 
 
-def _is_cancelled(job: Job) -> bool:
-    return job._current_status() == Status.CANCELLED.value
+def _ensure_cancelled_persisted(job: Job) -> None:
+    """Retry Cancelled snapshot if FSM is cancelled but the store lags."""
+    saved = Job.get_saved(job.id)
+    if saved is not None and saved.status == Status.CANCELLED.value:
+        return
+    job.save()
 
 
 class Worker:
@@ -48,8 +53,9 @@ class Worker:
             await self.run_once()
 
     async def _process(self, job: Job) -> None:
-        if _is_cancelled(job):
+        if job.is_cancelled():
             log.info(f"Job already cancelled, skip: id={job.id}")
+            _ensure_cancelled_persisted(job)
             return
 
         prev_state = job._fsm.current()
@@ -58,11 +64,26 @@ class Worker:
         try:
             job.save()
         except Exception as save_exc:
-            # Prefer persisting Failed; if that also fails, restore pre-RUN state.
+            # Prefer persisting Failed; if that also fails, restore pre-RUN state
+            # unless cancel already won (do not undo Cancelled in-memory).
             try:
                 job.apply_event(events.FAIL)
                 job.save()
             except Exception as fail_save_exc:
+                if job.is_cancelled():
+                    try:
+                        _ensure_cancelled_persisted(job)
+                    except Exception as cancel_save_exc:
+                        log.error(
+                            f"Job RUN persist failed: id={job.id}, error={save_exc}; "
+                            f"cancel won but Cancelled persist failed: {cancel_save_exc}"
+                        )
+                        raise save_exc from cancel_save_exc
+                    log.error(
+                        f"Job RUN persist failed: id={job.id}, error={save_exc}; "
+                        f"cancel already applied (skip restore): {fail_save_exc}"
+                    )
+                    raise save_exc from fail_save_exc
                 job.restore_lifecycle(prev_state, prev_status)
                 log.error(
                     f"Job RUN persist failed: id={job.id}, error={save_exc}; FAIL persist also failed: {fail_save_exc}"
@@ -77,14 +98,22 @@ class Worker:
         try:
             workflows = getattr(job, "workflows", None) or []
             for workflow in workflows:
-                if _is_cancelled(job):
-                    log.info(f"Job cancelled during work: id={job.id}")
+                if job.is_cancelled():
+                    log.info(f"Job cancelled between workflows: id={job.id}")
+                    _ensure_cancelled_persisted(job)
                     return
                 # Workflow.run is sync; run it in a worker thread.
                 await asyncio.to_thread(workflow.run)
         except Exception as e:
-            if _is_cancelled(job):
-                log.info(f"Job cancelled (after workflow error ignored): id={job.id}")
+            if job.is_cancelled():
+                log.info(f"Job cancelled (workflow error ignored): id={job.id}, error={e}")
+                try:
+                    _ensure_cancelled_persisted(job)
+                except Exception as save_exc:
+                    log.error(
+                        f"Job cancelled but Cancelled persist failed: id={job.id}; retry job.save only: {save_exc}"
+                    )
+                    raise save_exc from e
                 return
             try:
                 _transition_and_save_terminal(job, events.FAIL)
@@ -97,8 +126,9 @@ class Worker:
             log.error(f"Job failed: id={job.id}, error={e}")
             raise
 
-        if _is_cancelled(job):
+        if job.is_cancelled():
             log.info(f"Job cancelled before complete: id={job.id}")
+            _ensure_cancelled_persisted(job)
             return
 
         try:

--- a/tests/fsm/test_fsm_restore.py
+++ b/tests/fsm/test_fsm_restore.py
@@ -1,0 +1,45 @@
+"""FSM restore API tests."""
+
+from pypepper.event import event
+from pypepper.fsm import fsm
+
+
+def test_restore_sets_current_without_transition():
+    evt = event.new()
+    evt.set_name("Open")
+    evt.set_src("Closed")
+
+    machine = fsm.new(
+        fsm.Options(
+            fsm_id="restore-test",
+            initial=fsm.State("Closed"),
+            transitions=[
+                fsm.Transition(
+                    event=evt,
+                    from_state=[fsm.State("Closed")],
+                    to_state=fsm.State("Opened"),
+                )
+            ],
+        )
+    )
+
+    assert machine.current().value == "Closed"
+    machine.restore(fsm.State("Opened"))
+    assert machine.current().value == "Opened"
+
+    # Restored state is not a transition; Open from Opened is invalid.
+    rsp = machine.on(evt)
+    assert rsp.error is not None
+    assert machine.current().value == "Opened"
+
+
+def test_restore_none_clears_current():
+    machine = fsm.new(
+        fsm.Options(
+            fsm_id="restore-none",
+            initial=fsm.State("A"),
+            transitions=[],
+        )
+    )
+    machine.restore(None)
+    assert machine.current() is None

--- a/tests/scheduler/test_cancel.py
+++ b/tests/scheduler/test_cancel.py
@@ -299,6 +299,50 @@ async def test_worker_rethrows_when_cancel_persist_lags_after_workflow_error():
 
 
 @pytest.mark.asyncio
+async def test_worker_run_persist_fail_skips_restore_when_cancel_won():
+    """RUN save fails while cancel already applied: keep Cancelled, do not restore Scheduled."""
+
+    class _RaceStore(InMemoryJobStore):
+        job: Job | None = None
+
+        def put(self, record: JobRecord) -> None:
+            if record.status == Status.IN_PROGRESS.value:
+                assert self.job is not None
+                # Concurrent cancel wins after RUN applied in memory.
+                self.job.apply_event(events.CANCEL)
+                raise RuntimeError("run-persist-failed")
+            if record.status == Status.FAILED.value:
+                raise RuntimeError("fail-persist-failed")
+            super().put(record)
+
+    store = _RaceStore()
+    set_job_store(store)
+    executed = []
+
+    def work(task, context):
+        executed.append(task.name)
+        return "ok"
+
+    job = _job_with_workflow(work, channel_id="cancel-run-race")
+    store.job = job
+    job.save()
+
+    chan = Channel()
+    await chan.send(job)
+    with pytest.raises(RuntimeError, match="run-persist-failed"):
+        await Worker(chan).run_once()
+
+    assert executed == []
+    assert job.is_cancelled()
+    assert job._fsm.current().value == Status.CANCELLED
+    # Must not have been restored to Scheduled.
+    assert job.status != Status.SCHEDULED.value
+    saved = Job.get_saved(job.id)
+    assert saved is not None
+    assert saved.status == Status.CANCELLED.value
+
+
+@pytest.mark.asyncio
 async def test_channel_stop_does_not_cancel_queued_job():
     executed = []
 

--- a/tests/scheduler/test_cancel.py
+++ b/tests/scheduler/test_cancel.py
@@ -1,0 +1,175 @@
+"""Job / Worker cancel path tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from pypepper.exceptions import InternalException
+from pypepper.scheduler import events
+from pypepper.scheduler.channel import Channel
+from pypepper.scheduler.executor import CallableExecutor
+from pypepper.scheduler.job import Job
+from pypepper.scheduler.status import Status
+from pypepper.scheduler.store import reset_job_store
+from pypepper.scheduler.task import Task
+from pypepper.scheduler.worker import Worker
+from pypepper.scheduler.workflow import Workflow
+
+
+@pytest.fixture(autouse=True)
+def _fresh_job_store():
+    reset_job_store()
+    yield
+    reset_job_store()
+
+
+def _job_with_workflow(work, *, channel_id: str = "cancel-ch") -> Job:
+    workflow = Workflow()
+    workflow.add_task(
+        Task(
+            channel_id=channel_id,
+            dag_id="dag",
+            fingerprint="fp",
+            name="step1",
+            category="c",
+            description="",
+            tags=[],
+            executor=CallableExecutor(work),
+        )
+    )
+    job = Job(category="test", channel_id=channel_id)
+    job.workflows = [workflow]
+    job.apply_event(events.INIT)
+    job.apply_event(events.SCHEDULE)
+    return job
+
+
+def test_cancel_from_scheduled_persists_cancelled():
+    job = Job(category="test", channel_id="cancel-sched")
+    job.scheduled()
+    assert job._fsm.current().value == Status.SCHEDULED
+
+    job.cancel()
+
+    assert job._fsm.current().value == Status.CANCELLED
+    saved = Job.get_saved(job.id)
+    assert saved is not None
+    assert saved.status == Status.CANCELLED.value
+
+
+def test_cancel_from_in_progress_persists_cancelled():
+    job = Job(category="test", channel_id="cancel-run")
+    job.apply_event(events.INIT)
+    job.apply_event(events.SCHEDULE)
+    job.apply_event(events.RUN)
+    job.save()
+
+    job.cancel()
+
+    assert job._fsm.current().value == Status.CANCELLED
+    saved = Job.get_saved(job.id)
+    assert saved is not None
+    assert saved.status == Status.CANCELLED.value
+
+
+def test_cancel_from_completed_raises_and_does_not_dirty_store():
+    job = Job(category="test", channel_id="cancel-done")
+    job.apply_event(events.INIT)
+    job.apply_event(events.SCHEDULE)
+    job.apply_event(events.RUN)
+    job.apply_event(events.COMPLETE)
+    job.save()
+    before = Job.get_saved(job.id)
+    assert before is not None
+    assert before.status == Status.COMPLETED.value
+
+    with pytest.raises(InternalException):
+        job.cancel()
+
+    assert job._fsm.current().value == Status.COMPLETED
+    after = Job.get_saved(job.id)
+    assert after is not None
+    assert after.status == Status.COMPLETED.value
+
+
+def test_fsm_cancel_transition_from_scheduled_and_in_progress():
+    machine = events.build_scheduler_fsm()
+    assert machine.on(events.INIT).error is None
+    assert machine.on(events.SCHEDULE).error is None
+    assert machine.on(events.CANCEL).error is None
+    assert machine.current().value == Status.CANCELLED
+
+    machine2 = events.build_scheduler_fsm()
+    assert machine2.on(events.INIT).error is None
+    assert machine2.on(events.SCHEDULE).error is None
+    assert machine2.on(events.RUN).error is None
+    assert machine2.on(events.CANCEL).error is None
+    assert machine2.current().value == Status.CANCELLED
+
+
+@pytest.mark.asyncio
+async def test_worker_skips_already_cancelled_job():
+    executed = []
+
+    def work(task, context):
+        executed.append(task.name)
+        return "ok"
+
+    job = _job_with_workflow(work)
+    job.cancel()
+    assert job._fsm.current().value == Status.CANCELLED
+
+    chan = Channel()
+    await chan.send(job)
+    processed = await Worker(chan).run_once()
+
+    assert processed is job
+    assert executed == []
+    assert job._fsm.current().value == Status.CANCELLED
+    saved = Job.get_saved(job.id)
+    assert saved is not None
+    assert saved.status == Status.CANCELLED.value
+
+
+@pytest.mark.asyncio
+async def test_worker_does_not_complete_when_cancelled_mid_run():
+    hold = {"cancel_job": None}
+
+    def work(task, context):
+        job = hold["cancel_job"]
+        assert job is not None
+        job.cancel()
+        return "ok"
+
+    job = _job_with_workflow(work)
+    hold["cancel_job"] = job
+    job.save()
+
+    chan = Channel()
+    await chan.send(job)
+    await Worker(chan).run_once()
+
+    assert job._fsm.current().value == Status.CANCELLED
+    saved = Job.get_saved(job.id)
+    assert saved is not None
+    assert saved.status == Status.CANCELLED.value
+
+
+@pytest.mark.asyncio
+async def test_channel_stop_does_not_cancel_job():
+    executed = []
+
+    def work(task, context):
+        executed.append(task.name)
+        return "ok"
+
+    job = _job_with_workflow(work, channel_id="stop-vs-cancel")
+    job.save()
+
+    chan = Channel()
+    chan.stop = True
+    worker = Worker(chan)
+    assert await worker.run_once() is None
+
+    assert job._fsm.current().value == Status.SCHEDULED
+    assert executed == []

--- a/tests/scheduler/test_cancel.py
+++ b/tests/scheduler/test_cancel.py
@@ -10,7 +10,8 @@ from pypepper.scheduler.channel import Channel
 from pypepper.scheduler.executor import CallableExecutor
 from pypepper.scheduler.job import Job
 from pypepper.scheduler.status import Status
-from pypepper.scheduler.store import reset_job_store
+from pypepper.scheduler.store import JobRecord, reset_job_store, set_job_store
+from pypepper.scheduler.store.memory import InMemoryJobStore
 from pypepper.scheduler.task import Task
 from pypepper.scheduler.worker import Worker
 from pypepper.scheduler.workflow import Workflow
@@ -23,22 +24,34 @@ def _fresh_job_store():
     reset_job_store()
 
 
-def _job_with_workflow(work, *, channel_id: str = "cancel-ch") -> Job:
+def _assert_cancelled(job: Job) -> None:
+    assert job.is_cancelled()
+    assert job._fsm.current().value == Status.CANCELLED
+    saved = Job.get_saved(job.id)
+    assert saved is not None
+    assert saved.status == Status.CANCELLED.value
+
+
+def _workflow(work, *, name: str = "step1", channel_id: str = "cancel-ch") -> Workflow:
     workflow = Workflow()
     workflow.add_task(
         Task(
             channel_id=channel_id,
             dag_id="dag",
-            fingerprint="fp",
-            name="step1",
+            fingerprint=f"fp-{name}",
+            name=name,
             category="c",
             description="",
             tags=[],
             executor=CallableExecutor(work),
         )
     )
+    return workflow
+
+
+def _job_with_workflow(work, *, channel_id: str = "cancel-ch") -> Job:
     job = Job(category="test", channel_id=channel_id)
-    job.workflows = [workflow]
+    job.workflows = [_workflow(work, channel_id=channel_id)]
     job.apply_event(events.INIT)
     job.apply_event(events.SCHEDULE)
     return job
@@ -50,11 +63,7 @@ def test_cancel_from_scheduled_persists_cancelled():
     assert job._fsm.current().value == Status.SCHEDULED
 
     job.cancel()
-
-    assert job._fsm.current().value == Status.CANCELLED
-    saved = Job.get_saved(job.id)
-    assert saved is not None
-    assert saved.status == Status.CANCELLED.value
+    _assert_cancelled(job)
 
 
 def test_cancel_from_in_progress_persists_cancelled():
@@ -65,31 +74,61 @@ def test_cancel_from_in_progress_persists_cancelled():
     job.save()
 
     job.cancel()
-
-    assert job._fsm.current().value == Status.CANCELLED
-    saved = Job.get_saved(job.id)
-    assert saved is not None
-    assert saved.status == Status.CANCELLED.value
+    _assert_cancelled(job)
 
 
-def test_cancel_from_completed_raises_and_does_not_dirty_store():
-    job = Job(category="test", channel_id="cancel-done")
-    job.apply_event(events.INIT)
-    job.apply_event(events.SCHEDULE)
-    job.apply_event(events.RUN)
-    job.apply_event(events.COMPLETE)
-    job.save()
+@pytest.mark.parametrize(
+    "setup",
+    [
+        pytest.param(lambda j: None, id="unknown"),
+        pytest.param(
+            lambda j: (j.apply_event(events.INIT), None)[1],
+            id="initializing",
+        ),
+        pytest.param(
+            lambda j: (
+                j.apply_event(events.INIT),
+                j.apply_event(events.SCHEDULE),
+                j.apply_event(events.RUN),
+                j.apply_event(events.COMPLETE),
+                j.save(),
+            ),
+            id="completed",
+        ),
+        pytest.param(
+            lambda j: (
+                j.apply_event(events.INIT),
+                j.apply_event(events.SCHEDULE),
+                j.apply_event(events.RUN),
+                j.apply_event(events.FAIL),
+                j.save(),
+            ),
+            id="failed",
+        ),
+        pytest.param(
+            lambda j: (
+                j.apply_event(events.INIT),
+                j.apply_event(events.SCHEDULE),
+                j.cancel(),
+            ),
+            id="already-cancelled",
+        ),
+    ],
+)
+def test_cancel_illegal_states_raise_without_dirty_write(setup):
+    job = Job(category="test", channel_id="cancel-illegal")
+    setup(job)
     before = Job.get_saved(job.id)
-    assert before is not None
-    assert before.status == Status.COMPLETED.value
+    before_status = before.status if before else None
+    before_fsm = job._fsm.current().value if job._fsm.current() else None
 
     with pytest.raises(InternalException):
         job.cancel()
 
-    assert job._fsm.current().value == Status.COMPLETED
+    assert (job._fsm.current().value if job._fsm.current() else None) == before_fsm
     after = Job.get_saved(job.id)
-    assert after is not None
-    assert after.status == Status.COMPLETED.value
+    after_status = after.status if after else None
+    assert after_status == before_status
 
 
 def test_fsm_cancel_transition_from_scheduled_and_in_progress():
@@ -107,6 +146,29 @@ def test_fsm_cancel_transition_from_scheduled_and_in_progress():
     assert machine2.current().value == Status.CANCELLED
 
 
+def test_cancel_save_failure_keeps_fsm_cancelled():
+    class _FailCancelledStore(InMemoryJobStore):
+        def put(self, record: JobRecord) -> None:
+            if record.status == Status.CANCELLED.value:
+                raise RuntimeError("cancel-persist-failed")
+            super().put(record)
+
+    set_job_store(_FailCancelledStore())
+    job = Job(category="test", channel_id="cancel-save-fail")
+    job.apply_event(events.INIT)
+    job.apply_event(events.SCHEDULE)
+    job.save()
+
+    with pytest.raises(RuntimeError, match="cancel-persist-failed"):
+        job.cancel()
+
+    assert job.is_cancelled()
+    assert job._fsm.current().value == Status.CANCELLED
+    saved = Job.get_saved(job.id)
+    assert saved is not None
+    assert saved.status == Status.SCHEDULED.value
+
+
 @pytest.mark.asyncio
 async def test_worker_skips_already_cancelled_job():
     executed = []
@@ -117,7 +179,7 @@ async def test_worker_skips_already_cancelled_job():
 
     job = _job_with_workflow(work)
     job.cancel()
-    assert job._fsm.current().value == Status.CANCELLED
+    _assert_cancelled(job)
 
     chan = Channel()
     await chan.send(job)
@@ -125,10 +187,8 @@ async def test_worker_skips_already_cancelled_job():
 
     assert processed is job
     assert executed == []
-    assert job._fsm.current().value == Status.CANCELLED
-    saved = Job.get_saved(job.id)
-    assert saved is not None
-    assert saved.status == Status.CANCELLED.value
+    _assert_cancelled(job)
+    assert job.status != Status.IN_PROGRESS.value
 
 
 @pytest.mark.asyncio
@@ -147,16 +207,99 @@ async def test_worker_does_not_complete_when_cancelled_mid_run():
 
     chan = Channel()
     await chan.send(job)
-    await Worker(chan).run_once()
+    processed = await Worker(chan).run_once()
 
-    assert job._fsm.current().value == Status.CANCELLED
-    saved = Job.get_saved(job.id)
-    assert saved is not None
-    assert saved.status == Status.CANCELLED.value
+    assert processed is job
+    _assert_cancelled(job)
 
 
 @pytest.mark.asyncio
-async def test_channel_stop_does_not_cancel_job():
+async def test_worker_skips_second_workflow_when_cancelled_between():
+    executed = []
+    hold = {"job": None}
+
+    def work1(task, context):
+        executed.append(task.name)
+        hold["job"].cancel()
+        return "ok"
+
+    def work2(task, context):
+        executed.append(task.name)
+        return "ok"
+
+    job = Job(category="test", channel_id="cancel-multi-wf")
+    job.workflows = [
+        _workflow(work1, name="wf1", channel_id="cancel-multi-wf"),
+        _workflow(work2, name="wf2", channel_id="cancel-multi-wf"),
+    ]
+    hold["job"] = job
+    job.apply_event(events.INIT)
+    job.apply_event(events.SCHEDULE)
+    job.save()
+
+    chan = Channel()
+    await chan.send(job)
+    await Worker(chan).run_once()
+
+    assert executed == ["wf1"]
+    _assert_cancelled(job)
+
+
+@pytest.mark.asyncio
+async def test_worker_ignores_workflow_error_after_cancel():
+    hold = {"job": None}
+
+    def work(task, context):
+        hold["job"].cancel()
+        raise RuntimeError("workflow-boom")
+
+    job = _job_with_workflow(work)
+    hold["job"] = job
+    job.save()
+
+    chan = Channel()
+    await chan.send(job)
+    processed = await Worker(chan).run_once()
+
+    assert processed is job
+    _assert_cancelled(job)
+    assert Job.get_saved(job.id).status != Status.FAILED.value
+
+
+@pytest.mark.asyncio
+async def test_worker_rethrows_when_cancel_persist_lags_after_workflow_error():
+    class _FailCancelledStore(InMemoryJobStore):
+        def put(self, record: JobRecord) -> None:
+            if record.status == Status.CANCELLED.value:
+                raise RuntimeError("cancel-persist-failed")
+            super().put(record)
+
+    set_job_store(_FailCancelledStore())
+    hold = {"job": None}
+
+    def work(task, context):
+        with pytest.raises(RuntimeError, match="cancel-persist-failed"):
+            hold["job"].cancel()
+        # FSM already Cancelled; raise so Worker hits the except+cancelled path
+        raise RuntimeError("workflow-boom")
+
+    job = _job_with_workflow(work)
+    hold["job"] = job
+    job.save()
+
+    chan = Channel()
+    await chan.send(job)
+    with pytest.raises(RuntimeError, match="cancel-persist-failed"):
+        await Worker(chan).run_once()
+
+    assert job.is_cancelled()
+    saved = Job.get_saved(job.id)
+    assert saved is not None
+    assert saved.status == Status.IN_PROGRESS.value
+
+
+@pytest.mark.asyncio
+async def test_channel_stop_does_not_cancel_queued_job():
     executed = []
 
     def work(task, context):
@@ -167,9 +310,14 @@ async def test_channel_stop_does_not_cancel_job():
     job.save()
 
     chan = Channel()
+    await chan.send(job)
     chan.stop = True
     worker = Worker(chan)
     assert await worker.run_once() is None
 
     assert job._fsm.current().value == Status.SCHEDULED
+    assert not job.is_cancelled()
     assert executed == []
+    saved = Job.get_saved(job.id)
+    assert saved is not None
+    assert saved.status == Status.SCHEDULED.value


### PR DESCRIPTION
## Summary

- Problem: CANCEL existed in the scheduler FSM but had no `Job`/`Worker` path; ghost config keys (`cluster`, heartbeat, JSON-RPC, etc.) implied unimplemented features; publish could upload without pretest; `restore_lifecycle` poked `_fsm._current`.
- Why it matters: Operators need cooperative cancel + honest config surface; tag releases should fail closed on red tests; lifecycle rollback should use a public FSM API.
- What changed: `Job.cancel()` + Worker boundary checks; `FSM.restore()`; remove unused Conf/YAML keys; `publish.yml` lint+pytest before PyPI; `example/scheduler/` E2E; docs/CHANGELOG.
- What did NOT change: heartbeat/JSON-RPC wiring; hard-kill of in-flight sync workflows; branch coverage gates; P3 (Docker Dependabot / tutorial marketing).

## Change Type (select all)

- [x] Feature
- [x] Docs
- [x] Chore/infra
- [ ] Bug fix
- [ ] Refactor
- [ ] Security hardening

## Scope (select all touched areas)

- [x] common
- [x] fsm
- [x] scheduler
- [x] CI/CD / infra
- [ ] event
- [ ] helper
- [ ] network

## Linked Issue/PR

- Closes #
- Related # (P2 from seventh panoramic review; follows P0 #35 / P1 #36)

## User-visible / Behavior Changes

- `Job.cancel()` cancels Scheduled/InProgress jobs and persists `Cancelled`.
- Worker skips already-cancelled jobs and does not COMPLETE after cancel at workflow boundaries.
- Removed unused YAML/config keys: `cluster`, `heartbeat`, `network.jsonRPCProxy`, HTTP(S) `timeout`, `log.mode`, `sse.enabled`, `sse.heartbeatIntervalSeconds`.
- Tag publish workflow runs lint + tests before upload.
- New example: `python example/scheduler/app.py`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Python 3.13 venv; `devenv/ci.yaml` up for DB-backed tests
- Relevant config (redacted): `./conf/app.config.yaml` (ghost keys removed)

### Steps

1. `make check && make docs`
2. `pytest --cov=pypepper --cov-fail-under=90 tests/`
3. `python example/scheduler/app.py`

### Expected

- Check/docs/tests green; example reaches COMPLETE; cancel tests cover Scheduled/InProgress/illegal/Worker skip.

### Actual

- 211 passed, ~92.9% coverage; example COMPLETE; check/docs OK.

## Evidence

- [x] Failing test/log before + passing after (new `tests/scheduler/test_cancel.py`, `tests/fsm/test_fsm_restore.py`)
- [x] Trace/log snippets (example scheduler run to COMPLETE)

## Human Verification (required)

- Verified scenarios: cancel from Scheduled/InProgress; illegal cancel no dirty store; Worker skip cancelled; mid-run cancel no COMPLETE; Channel.stop ≠ cancel; FSM restore; scheduler example E2E; ghost keys gone from config/YAML/architecture.
- Edge cases checked: cancel after COMPLETE raises; cooperative cancel at workflow boundary only.
- What you did **not** verify: full publish.yml on a real tag push; full CI matrix on GitHub Actions for this branch yet.

## Compatibility / Migration

- Backward compatible? (`No` for apps that depended on removed ghost YAML keys / Conf types)
- Config/env changes? (`Yes` — delete unused keys from app YAML if present)
- Migration needed? (`Yes` — remove `cluster`, `heartbeat`, `jsonRPCProxy`, timeouts, `log.mode`, `sse.enabled`, `sse.heartbeatIntervalSeconds` if you mirrored stock config)
- If yes, exact upgrade steps: drop those keys; keep `sse.streamTimeoutSeconds` and `scheduler.jobStore`.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR / branch.
- Files/config to restore: `pypepper/common/config.py`, `conf/app.config.yaml`, scheduler cancel/worker paths.
- Known bad symptoms reviewers should watch for: apps still reading removed Box keys (AttributeError); unexpected cancel leaving Cancelled without COMPLETE.

## Risks and Mitigations

- Risk: consumers relied on ghost YAML keys via Box attribute access.
  - Mitigation: CHANGELOG Removed section; architecture table updated; stock `conf/app.config.yaml` cleaned.
- Risk: cooperative cancel does not interrupt sync workflow mid-`to_thread`.
  - Mitigation: documented in scheduler guide; v1 boundary semantics intentional.