### PR TITLE
feat: P3 ecosystem trust (supply chain + reproducible sample)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,52 @@
+name: Bug report
+description: Report unexpected behavior or a regression
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Security-sensitive reports belong in [SECURITY.md](https://github.com/jovijovi/pypepper/blob/main/SECURITY.md), not here.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong in one or two sentences?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Minimal steps or a short script.
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: PyPepper version or git commit, and Python version.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, optional devenv services, relevant config (redact secrets).
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security advisory
+    url: https://github.com/jovijovi/pypepper/security/advisories/new
+    about: Report a vulnerability privately (see SECURITY.md).
+  - name: Documentation
+    url: https://jovijovi.github.io/pypepper/
+    about: Guides, tutorials, and API reference.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Propose a new capability or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this solve for users?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: Desired behavior, API sketch, or docs change.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Likely domain
+      options:
+        - label: common
+        - label: event / fsm
+        - label: scheduler
+        - label: network / SSE
+        - label: helper / DB
+        - label: docs / CI / packaging

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+  - package-ecosystem: docker
+    directory: /docker
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,11 @@ jobs:
       - name: Docs
         run: make docs
 
+      - name: Audit production requirements
+        run: |
+          python -m pip install pip-audit
+          python ./scripts/pip_audit.py
+
   test:
     needs: lint
     runs-on: ubuntu-latest

--- a/.pip-audit-ignore.txt
+++ b/.pip-audit-ignore.txt
@@ -1,0 +1,7 @@
+# Vulnerability IDs ignored by `make audit` / CI pip-audit (one ID per line).
+# Prefer fixing/upgrading; only add entries with a short reason and tracking note.
+#
+# Example:
+# GHSA-xxxx-xxxx-xxxx  # reason; track in issue #N
+#
+# Empty by default: any known vuln in requirements.txt fails the audit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Scheduler E2E example (`example/scheduler/app.py`).
 - Tag publish workflow runs lint + pytest before PyPI upload.
 - Dependabot Docker updates for `docker/` (python base `FROM` lines Dependabot-visible).
+- CI / `make audit` run `pip-audit` on production `requirements.txt` (ignores via `.pip-audit-ignore.txt`).
 
 ### Removed
 - Unused ghost config types/keys: `cluster`, `heartbeat`, `network.jsonRPCProxy`, HTTP(S) `timeout`, `log.mode`, `sse.enabled`, `sse.heartbeatIntervalSeconds`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - `Job.cancel()` for Scheduled/InProgress jobs; Worker skips cancelled jobs and does not COMPLETE after cancel at workflow boundaries.
 - Scheduler E2E example (`example/scheduler/app.py`).
 - Tag publish workflow runs lint + pytest before PyPI upload.
-- Dependabot Docker updates for `docker/` (python base `FROM` lines Dependabot-visible).
+- Dependabot Docker updates for `docker/` (literal `FROM python:3.13.14-slim-trixie` pins, aligned with Makefile).
 - CI / `make audit` run `pip-audit` on production `requirements.txt` (ignores via `.pip-audit-ignore.txt`).
 - Tutorial: [First service](docs/tutorials/first-service.md) (scheduler COMPLETE + optional SSE).
 - `CONTRIBUTING.md` and GitHub issue templates.
@@ -19,7 +19,7 @@
 - Scheduler `CANCEL` FSM transition accepts Scheduled and InProgress.
 - Worker retries Cancelled persist on cancel exits and does not restore pre-RUN over a winning cancel; cancel persist failures are surfaced.
 - Docs: architecture config table drops ghost keys; scheduler guide / CLAUDE / AGENTS Start(`RUN`) note cancel-won skip-restore; Cancel persist rules separated from Worker COMPLETE/FAIL.
-- `digest.get` / `get_hex_str` emit a one-shot warning for `md5`/`sha1` (still compute; may reject in a future major). Prefer `sha256+`. ECDSA MD5/SHA1 retained for legacy verify only.
+- `digest.get` / `get_hex_str` emit a one-shot warning for `md5`/`sha1` (still compute; may reject in a future major). Prefer `sha256+`. ECDSA MD5/SHA1 remain for legacy compatibility (discouraged for new signing).
 
 ## 0.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Tag publish workflow runs lint + pytest before PyPI upload.
 - Dependabot Docker updates for `docker/` (python base `FROM` lines Dependabot-visible).
 - CI / `make audit` run `pip-audit` on production `requirements.txt` (ignores via `.pip-audit-ignore.txt`).
+- Tutorial: [First service](docs/tutorials/first-service.md) (scheduler COMPLETE + optional SSE).
 
 ### Removed
 - Unused ghost config types/keys: `cluster`, `heartbeat`, `network.jsonRPCProxy`, HTTP(S) `timeout`, `log.mode`, `sse.enabled`, `sse.heartbeatIntervalSeconds`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Scheduler `CANCEL` FSM transition accepts Scheduled and InProgress.
 - Worker retries Cancelled persist on cancel exits and does not restore pre-RUN over a winning cancel; cancel persist failures are surfaced.
 - Docs: architecture config table drops ghost keys; scheduler guide / CLAUDE / AGENTS Start(`RUN`) note cancel-won skip-restore; Cancel persist rules separated from Worker COMPLETE/FAIL.
+- `digest.get` / `get_hex_str` emit a one-shot warning for `md5`/`sha1` (still compute; may reject in a future major). Prefer `sha256+`. ECDSA MD5/SHA1 retained for legacy verify only.
 
 ## 0.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Dependabot Docker updates for `docker/` (python base `FROM` lines Dependabot-visible).
 - CI / `make audit` run `pip-audit` on production `requirements.txt` (ignores via `.pip-audit-ignore.txt`).
 - Tutorial: [First service](docs/tutorials/first-service.md) (scheduler COMPLETE + optional SSE).
+- `CONTRIBUTING.md` and GitHub issue templates.
 
 ### Removed
 - Unused ghost config types/keys: `cluster`, `heartbeat`, `network.jsonRPCProxy`, HTTP(S) `timeout`, `log.mode`, `sse.enabled`, `sse.heartbeatIntervalSeconds`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `Job.cancel()` for Scheduled/InProgress jobs; Worker skips cancelled jobs and does not COMPLETE after cancel at workflow boundaries.
 - Scheduler E2E example (`example/scheduler/app.py`).
 - Tag publish workflow runs lint + pytest before PyPI upload.
+- Dependabot Docker updates for `docker/` (python base `FROM` lines Dependabot-visible).
 
 ### Removed
 - Unused ghost config types/keys: `cluster`, `heartbeat`, `network.jsonRPCProxy`, HTTP(S) `timeout`, `log.mode`, `sse.enabled`, `sse.heartbeatIntervalSeconds`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing to PyPepper
+
+Thanks for helping improve PyPepper. This note covers the day-to-day path for
+code and docs contributions.
+
+## Security vulnerabilities
+
+Do **not** open a public issue for security-sensitive reports. Follow
+[`SECURITY.md`](SECURITY.md) (GitHub Security Advisories).
+
+## Development setup
+
+```shell
+make build-prepare   # clean + install requirements-dev.txt
+make check           # ruff + mypy + mutable class-attr guard
+make test            # check + pytest with coverage (>= 90%)
+```
+
+DB-backed tests need services from `devenv/ci.yaml`:
+
+```shell
+docker compose -f devenv/ci.yaml up -d --wait
+make test
+```
+
+Optional supply-chain check (also runs in the CI lint job):
+
+```shell
+make audit           # pip-audit on requirements.txt
+```
+
+Ignored vulns (if any) live in [`.pip-audit-ignore.txt`](.pip-audit-ignore.txt)
+with a reason — prefer upgrading instead of ignoring.
+
+Docs:
+
+```shell
+make docs            # mkdocs build --strict
+make docs-serve      # local preview
+```
+
+## Pull requests
+
+1. Branch from `main` (for example `feat/...` or `fix/...`).
+2. Keep the change focused; match existing package layout under `pypepper/` and
+   mirrored tests under `tests/`.
+3. Commit messages must follow
+   [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+   (for example `feat(scheduler): add cancel`).
+4. Fill out [`.github/pull_request_template.md`](.github/pull_request_template.md):
+   problem/fix, scope, security impact, repro, and evidence.
+5. Run `make check` and `make test` before opening the PR.
+
+## Style
+
+- Python `>=3.10, <=3.14`; 4-space indent; PEP 8; explicit type hints on public APIs.
+- Package-qualified imports (`from pypepper.common...`).
+- Do not declare mutable instance state as class attributes; initialize in
+  `__init__` / `__new__` (see `scripts/check_mutable_class_attrs.py`).
+
+## Questions
+
+Use GitHub Discussions or open an issue with the templates under
+[`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/).

--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,6 @@ docker:
 	  --load \
 	  --force-rm \
 	  -f $(DOCKER_FILE) \
-	  --build-arg PYTHON_VER=$(PYTHON_VER) \
-	  --build-arg IMAGE_TAG=$(IMAGE_TAG) \
 	  -t $(APP_NAME):$(APP_TAG) .
 	docker tag $(APP_NAME):$(APP_TAG) $(APP_NAME):latest
 	docker images|grep $(APP_NAME)

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ APP_TAG=$(VERSION).$(BUILD_TIME)
 VERSION_INFO='{"version":"$(VERSION)","gitCommit":"$(GIT_COMMIT)","commitTime":"$(COMMIT_TIME)","buildTime":"$(BUILD_TIME)","pythonVersion":"$(PYTHON_VER)"}'
 
 
-.PHONY: build-prepare debug test build docker clean publish-test publish help check lint docs docs-serve
+.PHONY: build-prepare debug test build docker clean publish-test publish help check lint docs docs-serve audit
 
 all: test clean docker
 
@@ -42,6 +42,11 @@ docs:
 docs-serve:
 	@echo "[BUILD] Serving documentation..."
 	mkdocs serve
+
+audit:
+	@echo "[BUILD] Auditing production requirements..."
+	python3 -m pip install -q pip-audit
+	python3 ./scripts/pip_audit.py
 
 check: lint
 	@echo "[BUILD] Checking mutable class attributes..."

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ PyPepper packages the pieces you wire into services: **HTTP / SSE**, **FSM**, a 
 
 Source under [`docs/`](docs/index.md). Local preview: `make docs-serve`.
 
+## Contributing
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for setup, Conventional Commits, and PR expectations.
+
 ## Security
 
 See [`SECURITY.md`](SECURITY.md) for supported versions and how to report vulnerabilities privately.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ PyPepper packages the pieces you wire into services: **HTTP / SSE**, **FSM**, a 
 
 ## Documentation
 
-[Getting Started](https://jovijovi.github.io/pypepper/getting-started/) · [Architecture](https://jovijovi.github.io/pypepper/architecture/) · [Guides](https://jovijovi.github.io/pypepper/guides/common/) · [API Reference](https://jovijovi.github.io/pypepper/reference/)
+[Getting Started](https://jovijovi.github.io/pypepper/getting-started/) · [Tutorial](https://jovijovi.github.io/pypepper/tutorials/first-service/) · [Architecture](https://jovijovi.github.io/pypepper/architecture/) · [Guides](https://jovijovi.github.io/pypepper/guides/common/) · [API Reference](https://jovijovi.github.io/pypepper/reference/)
 
 Source under [`docs/`](docs/index.md). Local preview: `make docs-serve`.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,18 @@
 # syntax=docker/dockerfile:1.25.0
+#
+# Dependabot (ecosystem: docker, directory: /docker) tracks python base images via
+# the explicit FROM python:... lines below. UV_IMAGE stays ARG-indirect (not the
+# primary Dependabot target).
 
-# Global args
+# Overridable via --build-arg (Makefile passes PYTHON_VER / IMAGE_TAG).
 ARG PYTHON_VER=3.13
 ARG IMAGE_TAG=slim
-ARG BASE_IMAGE=python:${PYTHON_VER}-${IMAGE_TAG}
 ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.28
 
 FROM ${UV_IMAGE} AS uvbin
 
 # ---------- STAGE: builder ----------
-FROM ${BASE_IMAGE} AS builder
+FROM python:${PYTHON_VER}-${IMAGE_TAG} AS builder
 
 COPY --from=uvbin /uv /uvx /bin/
 
@@ -40,7 +43,7 @@ RUN python ./scripts/build.py
 
 
 # ---------- STAGE: runtime ----------
-FROM ${BASE_IMAGE} AS runtime
+FROM python:${PYTHON_VER}-${IMAGE_TAG} AS runtime
 
 ARG APP_UID=10001
 ARG APP_GID=10001

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,18 +1,16 @@
 # syntax=docker/dockerfile:1.25.0
 #
-# Dependabot (ecosystem: docker, directory: /docker) tracks python base images via
-# the explicit FROM python:... lines below. UV_IMAGE stays ARG-indirect (not the
-# primary Dependabot target).
+# Dependabot (ecosystem: docker, directory: /docker) tracks the literal
+# FROM python:... pins below. Keep them in sync with Makefile PYTHON_VER /
+# IMAGE_TAG when bumping by hand. UV_IMAGE stays ARG-indirect (not the
+# primary Dependabot target). Dependabot cannot update ARG-interpolated FROM.
 
-# Overridable via --build-arg (Makefile passes PYTHON_VER / IMAGE_TAG).
-ARG PYTHON_VER=3.13
-ARG IMAGE_TAG=slim
 ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.28
 
 FROM ${UV_IMAGE} AS uvbin
 
 # ---------- STAGE: builder ----------
-FROM python:${PYTHON_VER}-${IMAGE_TAG} AS builder
+FROM python:3.13.14-slim-trixie AS builder
 
 COPY --from=uvbin /uv /uvx /bin/
 
@@ -43,7 +41,7 @@ RUN python ./scripts/build.py
 
 
 # ---------- STAGE: runtime ----------
-FROM python:${PYTHON_VER}-${IMAGE_TAG} AS runtime
+FROM python:3.13.14-slim-trixie AS runtime
 
 ARG APP_UID=10001
 ARG APP_GID=10001

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,6 +48,9 @@ config.load_config("./conf/app.config.yaml")
 setup_from_config(config.get_yml_config())
 ```
 
+For a guided walkthrough (expected COMPLETE output and common pitfalls), see
+[Tutorial: First service](tutorials/first-service.md).
+
 ### HTTP server
 
 ```shell

--- a/docs/guides/common.md
+++ b/docs/guides/common.md
@@ -67,8 +67,8 @@ Each `Cache` / `CacheSet` instance owns its own storage and locks.
 Prefer `sha256` (or stronger) for digests and new ECDSA signatures.
 `digest.get` / `get_hex_str` accept `md5` / `sha1` for compatibility but log a
 **one-shot** warning; a future major release may reject them.
-ECDSA `HashAlgorithmName.MD5` / `SHA1` remain available only for verifying legacy
-signatures — do not use them for new signing.
+ECDSA `HashAlgorithmName.MD5` / `SHA1` remain for legacy compatibility (sign and
+verify still accept them) — do not use them for new signing.
 
 ```python
 from pypepper.common.security.crypto import digest, salt

--- a/docs/guides/common.md
+++ b/docs/guides/common.md
@@ -64,6 +64,12 @@ Each `Cache` / `CacheSet` instance owns its own storage and locks.
 
 ## Crypto helpers
 
+Prefer `sha256` (or stronger) for digests and new ECDSA signatures.
+`digest.get` / `get_hex_str` accept `md5` / `sha1` for compatibility but log a
+**one-shot** warning; a future major release may reject them.
+ECDSA `HashAlgorithmName.MD5` / `SHA1` remain available only for verifying legacy
+signatures — do not use them for new signing.
+
 ```python
 from pypepper.common.security.crypto import digest, salt
 from pypepper.common.security.crypto.elliptic.ecdsa import ecdsa

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,9 +19,10 @@ Published docs: <https://jovijovi.github.io/pypepper/>
 ## Where to start
 
 1. [Getting Started](getting-started.md) — install, test, run examples
-2. [Architecture](architecture.md) — layering, extension points, singletons
-3. Domain guides under **Guides** for copy-paste snippets
-4. [API Reference](reference/index.md) — generated signatures and docstrings
+2. [Tutorial: First service](tutorials/first-service.md) — one path to COMPLETE (and optional SSE)
+3. [Architecture](architecture.md) — layering, extension points, singletons
+4. Domain guides under **Guides** for copy-paste snippets
+5. [API Reference](reference/index.md) — generated signatures and docstrings
 
 ## Examples
 

--- a/docs/makefile/help.txt
+++ b/docs/makefile/help.txt
@@ -17,6 +17,9 @@
 - Check (lint + mutable class attrs):
   make check
 
+- Audit production requirements (pip-audit):
+  make audit
+
 - Test:
   make test
 

--- a/docs/tutorials/first-service.md
+++ b/docs/tutorials/first-service.md
@@ -1,0 +1,88 @@
+# First service: config → job store → Job → Worker → COMPLETE
+
+This tutorial is a **single narrative path** with expected outcomes and common
+pitfalls. For install commands and the full example list, see
+[Getting Started](../getting-started.md).
+
+## Goal
+
+From a clean checkout, run the scheduler example so a job reaches **Completed**
+in the in-memory job store.
+
+## Prerequisites
+
+- Python `3.10`–`3.14` and repo dependencies (`make build-prepare` or
+  `uv pip install -r requirements-dev.txt` then `requirements.txt`)
+- Work from the **repository root** (config and example paths are relative)
+
+## Step 1 — Load config and wire the job store
+
+`config.load_config()` applies log/tracing settings. It does **not** configure a
+durable `scheduler.jobStore`. Always call `setup_from_config` after load when
+YAML declares a store (even `memory`).
+
+```python
+from pypepper.common.config import config
+from pypepper.scheduler.store import setup_from_config
+
+config.load_config("./conf/app.config.yaml")
+setup_from_config(config.get_yml_config())
+```
+
+!!! warning "Forgot `setup_from_config`?"
+    A non-`memory` `scheduler.jobStore.backend` in YAML only **warns** on load;
+    jobs still land in the default in-memory store until you call
+    `setup_from_config`.
+
+## Step 2 — Run the scheduler example
+
+```shell
+python example/scheduler/app.py
+```
+
+What it does:
+
+1. Builds a one-task workflow with `CallableExecutor`
+2. Calls `Job.scheduled()` in a **sync** context (required — no running event loop)
+3. Runs `Worker.run_once()` until the job finishes
+
+### Expected outcome
+
+Logs should include a line that the job completed, for example:
+
+```text
+job completed: id=... status=Completed
+```
+
+The process exits `0`. If an assertion fails inside the example, you will see a
+traceback instead.
+
+!!! failure "Called `scheduled()` from async code?"
+    `Job.scheduled()` / `Processor.run` raise `RuntimeError` when an event loop is
+    already running. Keep scheduling in sync code (as the example does), then
+    `asyncio.run` only the worker.
+
+## Step 3 (optional) — SSE echo stream
+
+In another terminal:
+
+```shell
+export PYPEPPER_SSE_API_KEY=your-local-key
+python example/sse/app.py
+```
+
+Connect:
+
+```shell
+curl -N -H "X-API-Key: $PYPEPPER_SSE_API_KEY" http://localhost:55550/sse/echo
+```
+
+You should see SSE event frames. Keep
+`sse.authentication.enabled: true` outside local experiments
+(see [SSE security notes](../guides/network-sse.md#security-notes)).
+
+## Next
+
+- [Scheduler guide](../guides/scheduler.md) — cancel, persistence, job stores
+- [Architecture](../architecture.md) — domain boundaries
+- [API Reference](../reference/index.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,8 @@ nav:
   - Home: index.md
   - Getting Started: getting-started.md
   - Architecture: architecture.md
+  - Tutorials:
+      - First service: tutorials/first-service.md
   - Guides:
       - Common: guides/common.md
       - Event and FSM: guides/event-fsm.md

--- a/pypepper/common/security/crypto/digest.py
+++ b/pypepper/common/security/crypto/digest.py
@@ -1,8 +1,37 @@
 """Hash digest helpers (bytes and hex)."""
 
+from __future__ import annotations
+
 import hashlib
+from threading import Lock
+
+from pypepper.common.log import log
 
 BinaryLike = str | bytes | bytearray | memoryview
+
+_WEAK_DIGEST_ALGS = frozenset({"md5", "sha1"})
+_weak_digest_warned = False
+_weak_digest_warn_lock = Lock()
+
+
+def _warn_weak_digest_once(alg: str) -> None:
+    """Log once that md5/sha1 digests are discouraged for new code."""
+    global _weak_digest_warned
+    with _weak_digest_warn_lock:
+        if _weak_digest_warned:
+            return
+        _weak_digest_warned = True
+    log.warn(
+        f"digest algorithm {alg!r} is weak (md5/sha1); prefer sha256+ for new code "
+        "(may be rejected in a future major release)"
+    )
+
+
+def reset_weak_digest_warning() -> None:
+    """Reset the one-shot weak-digest warning (tests)."""
+    global _weak_digest_warned
+    with _weak_digest_warn_lock:
+        _weak_digest_warned = False
 
 
 def get(data: BinaryLike, alg: str) -> bytes:
@@ -12,6 +41,10 @@ def get(data: BinaryLike, alg: str) -> bytes:
     :param alg: algorithm
     :return: hash (bytes)
     """
+
+    name = alg.lower()
+    if name in _WEAK_DIGEST_ALGS:
+        _warn_weak_digest_once(name)
 
     h = hashlib.new(alg)
 

--- a/scripts/pip_audit.py
+++ b/scripts/pip_audit.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Run pip-audit on requirements.txt, honoring .pip-audit-ignore.txt."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+IGNORE_FILE = ROOT / ".pip-audit-ignore.txt"
+REQUIREMENTS = ROOT / "requirements.txt"
+
+
+def _ignored_vulns() -> list[str]:
+    if not IGNORE_FILE.is_file():
+        return []
+    ids: list[str] = []
+    for raw in IGNORE_FILE.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        # Allow trailing comments after the ID.
+        vuln_id = line.split("#", 1)[0].strip().split()[0]
+        if vuln_id:
+            ids.append(vuln_id)
+    return ids
+
+
+def main() -> int:
+    cmd = [
+        sys.executable,
+        "-m",
+        "pip_audit",
+        "-r",
+        str(REQUIREMENTS),
+    ]
+    for vuln_id in _ignored_vulns():
+        cmd.extend(["--ignore-vuln", vuln_id])
+    print("+", " ".join(cmd), flush=True)
+    return subprocess.call(cmd)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/common/test_common_security_crypto_digest.py
+++ b/tests/common/test_common_security_crypto_digest.py
@@ -2,20 +2,41 @@ import pytest
 
 from pypepper.common.security.crypto import digest
 
-message = '1234567890'
-mock_hash_string = 'c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646'
+message = "1234567890"
+mock_hash_string = "c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646"
+
+
+@pytest.fixture(autouse=True)
+def _reset_weak_digest_warning():
+    digest.reset_weak_digest_warning()
+    yield
+    digest.reset_weak_digest_warning()
 
 
 def test_get():
-    result = digest.get(bytes(message, 'UTF-8'), 'sha256')
-    print("Hash(bytes)=", result)
+    result = digest.get(bytes(message, "UTF-8"), "sha256")
+    assert isinstance(result, bytes)
+    assert len(result) == 32
 
 
 def test_get_hex_str():
-    result = digest.get_hex_str(message, 'sha256')
-    print("Hash(hex)=", result)
+    result = digest.get_hex_str(message, "sha256")
     assert result == mock_hash_string
 
 
-if __name__ == '__main__':
-    pytest.main()
+def test_weak_digest_warns_once(monkeypatch):
+    from pypepper.common.log import log
+
+    warns: list[str] = []
+    monkeypatch.setattr(log, "warn", lambda msg, *a, **k: warns.append(str(msg)))
+    digest.reset_weak_digest_warning()
+    digest.get(b"x", "md5")
+    digest.get(b"y", "SHA1")
+    assert len(warns) == 1
+    assert "md5" in warns[0]
+    assert "weak" in warns[0]
+
+
+def test_weak_digest_still_returns_digest():
+    result = digest.get_hex_str(b"abc", "md5")
+    assert len(result) == 32

--- a/tests/common/test_common_security_crypto_digest.py
+++ b/tests/common/test_common_security_crypto_digest.py
@@ -1,9 +1,13 @@
+import hashlib
+
 import pytest
 
+from pypepper.common.log import log
 from pypepper.common.security.crypto import digest
 
 message = "1234567890"
 mock_hash_string = "c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646"
+mock_md5_abc = hashlib.md5(b"abc").hexdigest()
 
 
 @pytest.fixture(autouse=True)
@@ -24,12 +28,16 @@ def test_get_hex_str():
     assert result == mock_hash_string
 
 
-def test_weak_digest_warns_once(monkeypatch):
-    from pypepper.common.log import log
-
+def test_strong_digest_does_not_warn(monkeypatch):
     warns: list[str] = []
     monkeypatch.setattr(log, "warn", lambda msg, *a, **k: warns.append(str(msg)))
-    digest.reset_weak_digest_warning()
+    digest.get(b"x", "sha256")
+    assert warns == []
+
+
+def test_weak_digest_warns_once(monkeypatch):
+    warns: list[str] = []
+    monkeypatch.setattr(log, "warn", lambda msg, *a, **k: warns.append(str(msg)))
     digest.get(b"x", "md5")
     digest.get(b"y", "SHA1")
     assert len(warns) == 1
@@ -37,6 +45,14 @@ def test_weak_digest_warns_once(monkeypatch):
     assert "weak" in warns[0]
 
 
+def test_weak_digest_sha1_first_warn_message(monkeypatch):
+    warns: list[str] = []
+    monkeypatch.setattr(log, "warn", lambda msg, *a, **k: warns.append(str(msg)))
+    digest.get(b"x", "SHA1")
+    assert len(warns) == 1
+    assert "sha1" in warns[0]
+
+
 def test_weak_digest_still_returns_digest():
     result = digest.get_hex_str(b"abc", "md5")
-    assert len(result) == 32
+    assert result == mock_md5_abc


### PR DESCRIPTION
## Summary

- Problem: After P2, engineering trust gaps remain on Dependabot Docker visibility, CI-visible dependency audit, weak digest guidance, a narrative tutorial distinct from Getting Started, and a clear contribution/issue path.
- Why it matters: Closes P3 (ecosystem + trust) on the path to overall ≥9.5 without redoing Trusted Publisher or chasing stars/downloads.
- What changed: Dependabot `docker` for `/docker` with Dependabot-visible python `FROM`; lint-job + `make audit` `pip-audit` (any CVE fails; `.pip-audit-ignore.txt`); one-shot `log.warn` for `md5`/`sha1` in digest helpers; MkDocs first-service tutorial; `CONTRIBUTING.md` + issue templates.
- What did NOT change: Trusted Publisher / tag→PyPI, OSV separate workflow, devenv compose image Dependabot, elliptic MD5/SHA1 hard removal, external blog/star campaigns.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] common
- [ ] event
- [ ] fsm
- [ ] helper
- [ ] network
- [ ] scheduler
- [x] CI/CD / infra

## Linked Issue/PR

- Related #37 (P2 prerequisite on main)
- Related panoramic review P3 / R7

## User-visible / Behavior Changes

- `digest.get` / `get_hex_str` with `md5`/`sha1` emit a process-wide one-shot warning; digests still compute.
- New docs: tutorial, CONTRIBUTING, issue forms; README links.
- CI lint fails on known vulns in production `requirements.txt` (unless ignored via `.pip-audit-ignore.txt`).
- Local: `make audit` (not part of default `make check`).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes` — CI/local `pip-audit` queries vulnerability data; Dependabot docker updates)
- Command/tool execution surface changed? (`Yes` — `make audit` / lint step runs `pip-audit`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: Audit only reads `requirements.txt` and public advisory data; ignores must be explicit in-repo. Digest warn is advisory only this release.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local `.venv`, Python project tools
- Relevant config (redacted): N/A

### Steps

1. `make check && make docs && make audit`
2. `make test`
3. Confirm Dependabot config includes `docker` → `/docker` and Dockerfile uses `FROM python:…`

### Expected

- Checks/docs/audit/tests pass; weak digest tests cover one-shot warn

### Actual

- `make check` / `make docs` / `make audit` OK (no known vulns)
- `make test`: 222 passed, coverage 93%

## Evidence

- [x] Failing test/log before + passing after (new digest warn-once tests)
- [x] Trace/log snippets (digest md5 one-shot warn observed in pytest)

## Human Verification (required)

- Verified scenarios: Dependabot yaml + Dockerfile FROM shape; pip-audit clean; digest warn-once + still-returns; mkdocs build with tutorial; CONTRIBUTING/issue templates present
- Edge cases checked: sha256 path unchanged; ignore-file convention present (empty of active ignores)
- What you did **not** verify: Dependabot opening a real docker PR on GitHub; live GitHub issue form UI render

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR / branch commits
- Files/config to restore: `.github/workflows/test.yaml` (drop pip-audit step), `.github/dependabot.yml` (drop docker), digest.py warn helpers
- Known bad symptoms reviewers should watch for: lint job red on transitive CVEs (use `.pip-audit-ignore.txt` with rationale if unblock needed); unexpected digest warn noise in logs using md5/sha1

## Risks and Mitigations

- Risk: `pip-audit` any-finding fail may block CI on transitive CVEs that cannot upgrade immediately
  - Mitigation: document ignores in `.pip-audit-ignore.txt` + CHANGELOG/PR note; do not invent severity filters
- Risk: Dependabot still cannot update ARG-indirect `UV_IMAGE`
  - Mitigation: intentional; primary track is python base `FROM`; noted in Dockerfile comment