### PR TITLE
fix!: eng polish (pip-audit pin, reject md5/sha1, jobStore fail-fast, branch cov)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Audit production requirements
         run: |
-          python -m pip install pip-audit
+          python -m pip install 'pip-audit==2.10.1'
           python ./scripts/pip_audit.py
 
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 ### Breaking
 - `digest.get` / `get_hex_str` reject `md5` / `sha1` with `ValueError` (one-shot warn removed).
-- ECDSA `HashAlgorithmName.MD5` / `SHA1` removed; those algorithms raise `InternalException`.
-- `config.load_config()` records a deferred durable `scheduler.jobStore.backend`; `Job.save` / `Job.get_saved` raise `ValueError` until `setup_from_config` (or `configure_job_store`) is called (was a warning only).
+- ECDSA `HashAlgorithmName.MD5` / `SHA1` removed from the enum (`AttributeError` on access); constructing those digests raises `InternalException`.
+- `config.load_config()` records a deferred durable `scheduler.jobStore.backend`; `Job.save` / `Job.get_saved` raise `ValueError` until `setup_from_config` / `configure_job_store` / `set_job_store` is called (was a warning only). Deferred is cleared when a non-memory store is already installed (configure-before-load / reload). `reset_job_store` re-arms deferred from the current YAML so memory cannot silently replace an undeclared durable backend.
 
 ### Added
 - Public `FSM.restore(state)` for lifecycle rollback; `Job.restore_lifecycle` uses it (no `_fsm._current` writes).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.6.2
+
 ### Breaking
 - `digest.get` / `get_hex_str` reject `md5` / `sha1` with `ValueError` (one-shot warn removed).
 - ECDSA `HashAlgorithmName.MD5` / `SHA1` removed; those algorithms raise `InternalException`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,18 @@
 
 ## Unreleased
 
+### Breaking
+- `digest.get` / `get_hex_str` reject `md5` / `sha1` with `ValueError` (one-shot warn removed).
+- ECDSA `HashAlgorithmName.MD5` / `SHA1` removed; those algorithms raise `InternalException`.
+- `config.load_config()` records a deferred durable `scheduler.jobStore.backend`; `Job.save` / `Job.get_saved` raise `ValueError` until `setup_from_config` (or `configure_job_store`) is called (was a warning only).
+
 ### Added
 - Public `FSM.restore(state)` for lifecycle rollback; `Job.restore_lifecycle` uses it (no `_fsm._current` writes).
 - `Job.cancel()` for Scheduled/InProgress jobs; Worker skips cancelled jobs and does not COMPLETE after cancel at workflow boundaries.
 - Scheduler E2E example (`example/scheduler/app.py`).
 - Tag publish workflow runs lint + pytest before PyPI upload.
 - Dependabot Docker updates for `docker/` (literal `FROM python:3.13.14-slim-trixie` pins, aligned with Makefile).
-- CI / `make audit` run `pip-audit` on production `requirements.txt` (ignores via `.pip-audit-ignore.txt`).
+- CI / `make audit` run `pip-audit==2.10.1` on production `requirements.txt` (ignores via `.pip-audit-ignore.txt`; auditor pinned in `requirements-dev`).
 - Tutorial: [First service](docs/tutorials/first-service.md) (scheduler COMPLETE + optional SSE).
 - `CONTRIBUTING.md` and GitHub issue templates.
 
@@ -19,7 +24,7 @@
 - Scheduler `CANCEL` FSM transition accepts Scheduled and InProgress.
 - Worker retries Cancelled persist on cancel exits and does not restore pre-RUN over a winning cancel; cancel persist failures are surfaced.
 - Docs: architecture config table drops ghost keys; scheduler guide / CLAUDE / AGENTS Start(`RUN`) note cancel-won skip-restore; Cancel persist rules separated from Worker COMPLETE/FAIL.
-- `digest.get` / `get_hex_str` emit a one-shot warning for `md5`/`sha1` (still compute; may reject in a future major). Prefer `sha256+`. ECDSA MD5/SHA1 remain for legacy compatibility (discouraged for new signing).
+- Coverage measurement includes branch coverage (`branch = true`); `fail_under` remains 90.
 
 ## 0.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Breaking
 - `digest.get` / `get_hex_str` reject `md5` / `sha1` with `ValueError` (one-shot warn removed).
 - ECDSA `HashAlgorithmName.MD5` / `SHA1` removed from the enum (`AttributeError` on access); constructing those digests raises `InternalException`.
-- `config.load_config()` records a deferred durable `scheduler.jobStore.backend`; `Job.save` / `Job.get_saved` raise `ValueError` until `setup_from_config` / `configure_job_store` / `set_job_store` is called (was a warning only). Deferred is cleared when a non-memory store is already installed (configure-before-load / reload). `reset_job_store` re-arms deferred from the current YAML so memory cannot silently replace an undeclared durable backend.
+- `config.load_config()` records a deferred durable `scheduler.jobStore.backend`; `Job.save` / `Job.get_saved` raise `ValueError` until `setup_from_config` / `configure_job_store` / `set_job_store` is called (was a warning only). Deferred is cleared when a non-memory store is already installed (configure-before-load / reload). `reset_job_store` re-arms deferred from the current YAML so memory cannot silently replace a YAML-declared but unapplied durable backend.
 
 ### Added
 - Public `FSM.restore(state)` for lifecycle rollback; `Job.restore_lifecycle` uses it (no `_fsm._current` writes).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ make test
 Optional supply-chain check (also runs in the CI lint job):
 
 ```shell
-make audit           # pip-audit on requirements.txt
+make audit           # pip-audit==2.10.1 on requirements.txt (pinned in requirements-dev)
 ```
 
 Ignored vulns (if any) live in [`.pip-audit-ignore.txt`](.pip-audit-ignore.txt)

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ docs-serve:
 
 audit:
 	@echo "[BUILD] Auditing production requirements..."
-	python3 -m pip install -q pip-audit
+	python3 -m pip install -q 'pip-audit==2.10.1'
 	python3 ./scripts/pip_audit.py
 
 check: lint

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,7 +88,7 @@ Runtime YAML lives in `conf/app.config.yaml`. Models vs runtime:
 | `log.level` / `log.colorize` | Live |
 | `sse` auth, rate limit, connection caps, `streamTimeoutSeconds`, `maxQueueSize` | Live (read at request/stream time) |
 | `tracing.*` | Live via `load_config` → tracing `setup_from_config` |
-| `scheduler.jobStore` | Live only after explicit `scheduler.store.setup_from_config` (not `load_config`) |
+| `scheduler.jobStore` | Live only after explicit `scheduler.store.setup_from_config` (not `load_config`). Durable backends are deferred until setup/configure/set; `Job.save` / `get_saved` raise until applied. `reset_job_store` re-arms deferred from current YAML. |
 | `custom` | App-defined |
 
 ## Observability

--- a/docs/guides/common.md
+++ b/docs/guides/common.md
@@ -17,8 +17,8 @@ print(yml.sse.authentication.enabled)
 It applies log level and optional tracing setup. It does **not** configure the scheduler job
 store — call `pypepper.scheduler.store.setup_from_config(config.get_yml_config())` after load
 when YAML includes `scheduler.jobStore` (see [Scheduler](scheduler.md)). If YAML declares a
-non-`memory` `jobStore.backend`, `load_config` logs a warning until you call
-`setup_from_config`.
+non-`memory` `jobStore.backend`, `Job.save` / `Job.get_saved` raise `ValueError` until you
+call `setup_from_config` (or `configure_job_store`).
 
 ## Logging
 
@@ -64,11 +64,10 @@ Each `Cache` / `CacheSet` instance owns its own storage and locks.
 
 ## Crypto helpers
 
-Prefer `sha256` (or stronger) for digests and new ECDSA signatures.
-`digest.get` / `get_hex_str` accept `md5` / `sha1` for compatibility but log a
-**one-shot** warning; a future major release may reject them.
-ECDSA `HashAlgorithmName.MD5` / `SHA1` remain for legacy compatibility (sign and
-verify still accept them) — do not use them for new signing.
+Prefer `sha256` (or stronger) for digests and ECDSA signatures.
+`digest.get` / `get_hex_str` reject `md5` / `sha1` with `ValueError`.
+ECDSA `HashAlgorithmName` no longer defines MD5/SHA1; passing those names to
+sign/verify raises `InternalException`.
 
 ```python
 from pypepper.common.security.crypto import digest, salt

--- a/docs/guides/common.md
+++ b/docs/guides/common.md
@@ -18,7 +18,9 @@ It applies log level and optional tracing setup. It does **not** configure the s
 store — call `pypepper.scheduler.store.setup_from_config(config.get_yml_config())` after load
 when YAML includes `scheduler.jobStore` (see [Scheduler](scheduler.md)). If YAML declares a
 non-`memory` `jobStore.backend`, `Job.save` / `Job.get_saved` raise `ValueError` until you
-call `setup_from_config` (or `configure_job_store`).
+call `setup_from_config`, `configure_job_store`, or `set_job_store`. If a non-memory store is
+already installed, a later durable `load_config` does not false-positive. `reset_job_store`
+re-arms deferred fail-fast from the current YAML.
 
 ## Logging
 

--- a/docs/guides/release.md
+++ b/docs/guides/release.md
@@ -34,7 +34,7 @@ git tag vX.Y.Z
 git push origin vX.Y.Z
 ```
 
-Example: if `pyproject.toml` has `version = "0.6.1"`, the tag must be `v0.6.1`.
+Example: if `pyproject.toml` has `version = "0.6.2"`, the tag must be `v0.6.2`.
 
 4. Watch **Actions → Publish to PyPI**. The workflow runs lint + tests first; a failing pretest or a tag/`pyproject.toml` version mismatch blocks upload.
 5. Confirm the version on [https://pypi.org/project/pypepper/](https://pypi.org/project/pypepper/).

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -116,7 +116,8 @@ assert get_job_store().get(job.id) is not None
 ```
 
 YAML (optional). `config.load_config()` does **not** apply this automatically — call
-`setup_from_config` after load (a durable `backend` without that call logs a warning):
+`setup_from_config` after load (a durable `backend` without that call makes
+`Job.save` / `Job.get_saved` raise `ValueError`):
 
 ```python
 from pypepper.common.config import config

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -116,8 +116,9 @@ assert get_job_store().get(job.id) is not None
 ```
 
 YAML (optional). `config.load_config()` does **not** apply this automatically — call
-`setup_from_config` after load (a durable `backend` without that call makes
-`Job.save` / `Job.get_saved` raise `ValueError`):
+`setup_from_config` after load (a durable `backend` without setup/configure/set makes
+`Job.save` / `Job.get_saved` raise `ValueError`; `reset_job_store` re-arms that guard
+from the current YAML):
 
 ```python
 from pypepper.common.config import config

--- a/docs/makefile/help.txt
+++ b/docs/makefile/help.txt
@@ -17,7 +17,7 @@
 - Check (lint + mutable class attrs):
   make check
 
-- Audit production requirements (pip-audit):
+- Audit production requirements (pip-audit==2.10.1, pinned with dev deps):
   make audit
 
 - Test:

--- a/docs/tutorials/first-service.md
+++ b/docs/tutorials/first-service.md
@@ -29,10 +29,10 @@ config.load_config("./conf/app.config.yaml")
 setup_from_config(config.get_yml_config())
 ```
 
-!!! warning "Forgot `setup_from_config`?"
-    A non-`memory` `scheduler.jobStore.backend` in YAML only **warns** on load;
-    jobs still land in the default in-memory store until you call
-    `setup_from_config`.
+!!! failure "Forgot `setup_from_config`?"
+    A non-`memory` `scheduler.jobStore.backend` in YAML makes `Job.save` /
+    `Job.get_saved` raise `ValueError` until you call `setup_from_config`
+    (or use `memory`).
 
 ## Step 2 — Run the scheduler example
 

--- a/docs/tutorials/first-service.md
+++ b/docs/tutorials/first-service.md
@@ -32,7 +32,8 @@ setup_from_config(config.get_yml_config())
 !!! failure "Forgot `setup_from_config`?"
     A non-`memory` `scheduler.jobStore.backend` in YAML makes `Job.save` /
     `Job.get_saved` raise `ValueError` until you call `setup_from_config`
-    (or use `memory`).
+    (or `configure_job_store` / `set_job_store`). Declaring `backend: memory`
+    does not arm that guard.
 
 ## Step 2 — Run the scheduler example
 

--- a/pypepper/common/config.py
+++ b/pypepper/common/config.py
@@ -98,8 +98,8 @@ class Config:
     _default_config_filepath = os.path.join(_default_config_path, _default_config_filename)
     _setting: Any = None
 
-    def __init__(self):
-        pass
+    def __init__(self) -> None:
+        self._deferred_durable_job_store_backend: str | None = None
 
     def _get_parser(self, **parser_kwargs):
         parser = argparse.ArgumentParser(**parser_kwargs)
@@ -134,10 +134,11 @@ class Config:
         from pypepper.common.tracing import setup_from_config
 
         setup_from_config(self.get_yml_config())
-        self._warn_if_scheduler_job_store_deferred()
+        self._record_scheduler_job_store_deferred()
 
-    def _warn_if_scheduler_job_store_deferred(self) -> None:
-        """Warn when YAML declares a durable jobStore that load_config does not apply."""
+    def _record_scheduler_job_store_deferred(self) -> None:
+        """Track durable jobStore from YAML until setup_from_config applies it."""
+        self._deferred_durable_job_store_backend = None
         yml = self.get_yml_config()
         if yml is None or not hasattr(yml, "scheduler") or yml.scheduler is None:
             return
@@ -150,9 +151,21 @@ class Config:
         name = str(backend).strip().lower()
         if name in ("", "memory"):
             return
-        log.warn(
+        self._deferred_durable_job_store_backend = str(backend)
+
+    def mark_scheduler_job_store_applied(self) -> None:
+        """Clear the deferred durable jobStore flag (called after setup/configure)."""
+        self._deferred_durable_job_store_backend = None
+
+    def ensure_scheduler_job_store_applied(self) -> None:
+        """Raise if YAML declared a durable jobStore that has not been applied yet."""
+        backend = self._deferred_durable_job_store_backend
+        if backend is None:
+            return
+        raise ValueError(
             f"scheduler.jobStore.backend={backend!r} is present in YAML but not applied by "
-            "load_config; call pypepper.scheduler.store.setup_from_config(...) after load"
+            "load_config; call pypepper.scheduler.store.setup_from_config(...) after load "
+            "before persisting jobs"
         )
 
     def get_yml_config(self) -> YmlConfig:

--- a/pypepper/common/config.py
+++ b/pypepper/common/config.py
@@ -134,10 +134,15 @@ class Config:
         from pypepper.common.tracing import setup_from_config
 
         setup_from_config(self.get_yml_config())
-        self._record_scheduler_job_store_deferred()
+        self.refresh_scheduler_job_store_deferred()
 
-    def _record_scheduler_job_store_deferred(self) -> None:
-        """Track durable jobStore from YAML until setup_from_config applies it."""
+    def refresh_scheduler_job_store_deferred(self) -> None:
+        """
+        Re-read durable ``scheduler.jobStore`` from the current YAML into the deferred flag.
+
+        Counterpart to :meth:`mark_scheduler_job_store_applied` (used by ``reset_job_store``
+        and ``load_config``). Memory / missing backends clear the flag.
+        """
         self._deferred_durable_job_store_backend = None
         yml = self.get_yml_config()
         if yml is None or not hasattr(yml, "scheduler") or yml.scheduler is None:
@@ -169,7 +174,7 @@ class Config:
         if backend is None:
             return
         if not using_default_memory_store:
-            self._deferred_durable_job_store_backend = None
+            self.mark_scheduler_job_store_applied()
             return
         raise ValueError(
             f"scheduler.jobStore.backend={backend!r} is present in YAML but not applied by "

--- a/pypepper/common/config.py
+++ b/pypepper/common/config.py
@@ -157,10 +157,19 @@ class Config:
         """Clear the deferred durable jobStore flag (called after setup/configure)."""
         self._deferred_durable_job_store_backend = None
 
-    def ensure_scheduler_job_store_applied(self) -> None:
-        """Raise if YAML declared a durable jobStore that has not been applied yet."""
+    def ensure_scheduler_job_store_applied(self, *, using_default_memory_store: bool = True) -> None:
+        """
+        Raise if YAML declared a durable jobStore that has not been applied yet.
+
+        When a non-memory store is already installed (``using_default_memory_store=False``),
+        treat the deferred declaration as satisfied so configure-before-load and reload
+        after setup do not false-positive.
+        """
         backend = self._deferred_durable_job_store_backend
         if backend is None:
+            return
+        if not using_default_memory_store:
+            self._deferred_durable_job_store_backend = None
             return
         raise ValueError(
             f"scheduler.jobStore.backend={backend!r} is present in YAML but not applied by "

--- a/pypepper/common/security/crypto/digest.py
+++ b/pypepper/common/security/crypto/digest.py
@@ -3,48 +3,25 @@
 from __future__ import annotations
 
 import hashlib
-from threading import Lock
-
-from pypepper.common.log import log
 
 BinaryLike = str | bytes | bytearray | memoryview
 
-_WEAK_DIGEST_ALGS = frozenset({"md5", "sha1"})
-_weak_digest_warned = False
-_weak_digest_warn_lock = Lock()
-
-
-def _warn_weak_digest_once(alg: str) -> None:
-    """Log once that md5/sha1 digests are discouraged for new code."""
-    global _weak_digest_warned
-    with _weak_digest_warn_lock:
-        if _weak_digest_warned:
-            return
-        _weak_digest_warned = True
-    log.warn(
-        f"digest algorithm {alg!r} is weak (md5/sha1); prefer sha256+ for new code "
-        "(may be rejected in a future major release)"
-    )
-
-
-def reset_weak_digest_warning() -> None:
-    """Reset the one-shot weak-digest warning (tests)."""
-    global _weak_digest_warned
-    with _weak_digest_warn_lock:
-        _weak_digest_warned = False
+_REJECTED_DIGEST_ALGS = frozenset({"md5", "sha1"})
 
 
 def get(data: BinaryLike, alg: str) -> bytes:
     """
     Get hash (bytes)
+
     :param data: data in BinaryLike style
-    :param alg: algorithm
+    :param alg: algorithm (``md5`` / ``sha1`` are rejected)
     :return: hash (bytes)
+    :raises ValueError: if ``alg`` is ``md5`` or ``sha1`` (case-insensitive)
     """
 
     name = alg.lower()
-    if name in _WEAK_DIGEST_ALGS:
-        _warn_weak_digest_once(name)
+    if name in _REJECTED_DIGEST_ALGS:
+        raise ValueError(f"digest algorithm {alg!r} is not allowed; use sha256 or stronger")
 
     h = hashlib.new(alg)
 
@@ -59,9 +36,11 @@ def get(data: BinaryLike, alg: str) -> bytes:
 def get_hex_str(data: BinaryLike, alg: str) -> str:
     """
     Get hash string (hex)
+
     :param data: data in BinaryLike style
-    :param alg: algorithm
+    :param alg: algorithm (``md5`` / ``sha1`` are rejected)
     :return: hash string (hex)
+    :raises ValueError: if ``alg`` is ``md5`` or ``sha1`` (case-insensitive)
     """
 
     return get(data, alg).hex()

--- a/pypepper/common/security/crypto/elliptic/algorithm.py
+++ b/pypepper/common/security/crypto/elliptic/algorithm.py
@@ -10,8 +10,6 @@ class HashAlgorithmName:
     Hash algorithm name
     """
 
-    MD5 = "md5"
-    SHA1 = "sha1"
     SHA224 = "sha224"
     SHA256 = "sha256"
     SHA384 = "sha384"
@@ -19,8 +17,6 @@ class HashAlgorithmName:
 
 
 hash_algorithms = {
-    HashAlgorithmName.MD5: hashes.MD5(),
-    HashAlgorithmName.SHA1: hashes.SHA1(),
     HashAlgorithmName.SHA224: hashes.SHA224(),
     HashAlgorithmName.SHA256: hashes.SHA256(),
     HashAlgorithmName.SHA384: hashes.SHA384(),

--- a/pypepper/scheduler/job.py
+++ b/pypepper/scheduler/job.py
@@ -237,8 +237,11 @@ class Job(IJob):
 
     def save(self) -> None:
         from pypepper.common.config import config as app_config
+        from pypepper.scheduler.store.memory import InMemoryJobStore
 
-        app_config.ensure_scheduler_job_store_applied()
+        app_config.ensure_scheduler_job_store_applied(
+            using_default_memory_store=isinstance(get_job_store(), InMemoryJobStore)
+        )
         status = self._current_status()
         updated = get_utc_datetime()
         record = JobRecord(
@@ -260,8 +263,11 @@ class Job(IJob):
     @staticmethod
     def get_saved(job_id: str) -> JobRecord | None:
         from pypepper.common.config import config as app_config
+        from pypepper.scheduler.store.memory import InMemoryJobStore
 
-        app_config.ensure_scheduler_job_store_applied()
+        app_config.ensure_scheduler_job_store_applied(
+            using_default_memory_store=isinstance(get_job_store(), InMemoryJobStore)
+        )
         return get_job_store().get(job_id)
 
     def log(self) -> None:

--- a/pypepper/scheduler/job.py
+++ b/pypepper/scheduler/job.py
@@ -236,6 +236,9 @@ class Job(IJob):
         )
 
     def save(self) -> None:
+        from pypepper.common.config import config as app_config
+
+        app_config.ensure_scheduler_job_store_applied()
         status = self._current_status()
         updated = get_utc_datetime()
         record = JobRecord(
@@ -256,6 +259,9 @@ class Job(IJob):
 
     @staticmethod
     def get_saved(job_id: str) -> JobRecord | None:
+        from pypepper.common.config import config as app_config
+
+        app_config.ensure_scheduler_job_store_applied()
         return get_job_store().get(job_id)
 
     def log(self) -> None:

--- a/pypepper/scheduler/store/__init__.py
+++ b/pypepper/scheduler/store/__init__.py
@@ -21,19 +21,34 @@ def get_job_store() -> IJobStore:
 job_store: IJobStore = _job_store
 
 
-def set_job_store(store: IJobStore) -> None:
-    """Replace the process-wide job store."""
-    global _job_store, job_store
-    _job_store = store
-    job_store = store
-
-
-def reset_job_store() -> None:
-    """Reset to a fresh in-memory store (tests)."""
-    set_job_store(InMemoryJobStore())
+def _mark_job_store_applied() -> None:
     from pypepper.common.config import config as app_config
 
     app_config.mark_scheduler_job_store_applied()
+
+
+def set_job_store(store: IJobStore) -> None:
+    """Replace the process-wide job store and clear any deferred durable YAML flag."""
+    global _job_store, job_store
+    _job_store = store
+    job_store = store
+    _mark_job_store_applied()
+
+
+def reset_job_store() -> None:
+    """
+    Reset to a fresh in-memory store (tests / process reset).
+
+    Does **not** acknowledge a deferred durable YAML backend: if the current
+    config still declares a non-memory ``jobStore``, deferred fail-fast is
+    re-armed so ``Job.save`` cannot silently use memory.
+    """
+    global _job_store, job_store
+    _job_store = InMemoryJobStore()
+    job_store = _job_store
+    from pypepper.common.config import config as app_config
+
+    app_config._record_scheduler_job_store_deferred()
 
 
 def configure_job_store(backend: Backend = "memory", **kwargs: Any) -> IJobStore:
@@ -62,9 +77,6 @@ def configure_job_store(backend: Backend = "memory", **kwargs: Any) -> IJobStore
         raise ValueError(f"unsupported job store backend: {backend!r}")
 
     set_job_store(store)
-    from pypepper.common.config import config as app_config
-
-    app_config.mark_scheduler_job_store_applied()
     return store
 
 
@@ -85,9 +97,7 @@ def setup_from_config(yml_config: Any | None = None) -> None:
     backend = cast(Backend, backend_raw)
     # Avoid wiping an existing in-memory store when config still says memory.
     if backend == "memory" and isinstance(get_job_store(), InMemoryJobStore):
-        from pypepper.common.config import config as app_config
-
-        app_config.mark_scheduler_job_store_applied()
+        _mark_job_store_applied()
         return
 
     kwargs: dict[str, Any] = {}

--- a/pypepper/scheduler/store/__init__.py
+++ b/pypepper/scheduler/store/__init__.py
@@ -48,7 +48,7 @@ def reset_job_store() -> None:
     job_store = _job_store
     from pypepper.common.config import config as app_config
 
-    app_config._record_scheduler_job_store_deferred()
+    app_config.refresh_scheduler_job_store_deferred()
 
 
 def configure_job_store(backend: Backend = "memory", **kwargs: Any) -> IJobStore:

--- a/pypepper/scheduler/store/__init__.py
+++ b/pypepper/scheduler/store/__init__.py
@@ -31,6 +31,9 @@ def set_job_store(store: IJobStore) -> None:
 def reset_job_store() -> None:
     """Reset to a fresh in-memory store (tests)."""
     set_job_store(InMemoryJobStore())
+    from pypepper.common.config import config as app_config
+
+    app_config.mark_scheduler_job_store_applied()
 
 
 def configure_job_store(backend: Backend = "memory", **kwargs: Any) -> IJobStore:
@@ -59,6 +62,9 @@ def configure_job_store(backend: Backend = "memory", **kwargs: Any) -> IJobStore
         raise ValueError(f"unsupported job store backend: {backend!r}")
 
     set_job_store(store)
+    from pypepper.common.config import config as app_config
+
+    app_config.mark_scheduler_job_store_applied()
     return store
 
 
@@ -79,6 +85,9 @@ def setup_from_config(yml_config: Any | None = None) -> None:
     backend = cast(Backend, backend_raw)
     # Avoid wiping an existing in-memory store when config still says memory.
     if backend == "memory" and isinstance(get_job_store(), InMemoryJobStore):
+        from pypepper.common.config import config as app_config
+
+        app_config.mark_scheduler_job_store_applied()
         return
 
     kwargs: dict[str, Any] = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
     "mypy==2.3.0",
     "packaging==26.2",
     "pip==26.1.2",
+    "pip-audit==2.10.1",
     "pytest==9.1.1",
     "pytest-asyncio==1.4.0",
     "pytest-cov==7.1.0",
@@ -65,7 +66,7 @@ dev = [
 
 [tool.coverage.run]
 source = ["pypepper"]
-branch = false
+branch = true
 
 [tool.coverage.report]
 fail_under = 90

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pypepper"
-version = "0.6.1"
+version = "0.6.2"
 authors = [
     { name = "jovijovi", email = "mageyul@hotmail.com" },
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ mkdocstrings[python]>=0.29
 mypy==2.3.0
 packaging==26.2
 pip==26.1.2
+pip-audit==2.10.1
 pytest==9.1.1
 pytest-asyncio==1.4.0
 pytest-cov==7.1.0

--- a/tests/common/test_common_config.py
+++ b/tests/common/test_common_config.py
@@ -1,10 +1,70 @@
 import pytest
 
 from pypepper.common.config import config
-from pypepper.common.log import log
 from pypepper.scheduler.job import Job
-from pypepper.scheduler.store import get_job_store, reset_job_store, setup_from_config
+from pypepper.scheduler.store import (
+    configure_job_store,
+    get_job_store,
+    reset_job_store,
+    set_job_store,
+    setup_from_config,
+)
+from pypepper.scheduler.store.interfaces import IJobStore, JobRecord
 from pypepper.scheduler.store.memory import InMemoryJobStore
+
+
+def _write_durable_cfg(tmp_path, name: str = "durable-jobstore.yaml"):
+    cfg = tmp_path / name
+    cfg.write_text(
+        "scheduler:\n"
+        "  jobStore:\n"
+        "    backend: postgres\n"
+        "    uri: postgresql+psycopg://postgres:example@localhost:5432/mock_pypepper\n"
+    )
+    return cfg
+
+
+def _restore_memory_config() -> None:
+    """Avoid leaving durable YAML in the process-wide config for later tests."""
+    config.load_config("./conf/app.config.yaml")
+    config.mark_scheduler_job_store_applied()
+
+
+class _NonMemoryStore(IJobStore):
+    """Minimal non-InMemory store for deferred / configure-before-load tests."""
+
+    def __init__(self) -> None:
+        self._rows: dict[str, JobRecord] = {}
+
+    def put(self, record: JobRecord) -> None:
+        existing = self._rows.get(record.id)
+        if existing is not None:
+            record = JobRecord(
+                id=record.id,
+                category=record.category,
+                channel_id=record.channel_id,
+                status=record.status,
+                created=existing.created,
+                updated=record.updated,
+                workflow_count=record.workflow_count,
+                version=record.version,
+            )
+        self._rows[record.id] = record
+
+    def get(self, job_id: str) -> JobRecord | None:
+        return self._rows.get(job_id)
+
+    def delete(self, job_id: str) -> None:
+        self._rows.pop(job_id, None)
+
+    def list(self, channel_id: str | None = None) -> list[JobRecord]:
+        rows = list(self._rows.values())
+        if channel_id is None:
+            return rows
+        return [r for r in rows if r.channel_id == channel_id]
+
+    def clear(self) -> None:
+        self._rows.clear()
 
 
 def test_load_config():
@@ -38,54 +98,114 @@ def test_load_config_does_not_configure_job_store(monkeypatch, tmp_path):
         lambda *a, **k: calls.append("configure_job_store"),
     )
 
-    cfg = tmp_path / "durable-jobstore.yaml"
-    cfg.write_text(
-        "scheduler:\n"
-        "  jobStore:\n"
-        "    backend: postgres\n"
-        "    uri: postgresql+psycopg://postgres:example@localhost:5432/mock_pypepper\n"
-    )
+    cfg = _write_durable_cfg(tmp_path)
+    try:
+        config.load_config(str(cfg))
 
-    reset_job_store()
-    config.mark_scheduler_job_store_applied()
-    config.load_config(str(cfg))
-
-    assert calls == []
-    assert isinstance(get_job_store(), InMemoryJobStore)
-    with pytest.raises(ValueError, match="setup_from_config"):
-        Job().save()
+        assert calls == []
+        assert isinstance(get_job_store(), InMemoryJobStore)
+        with pytest.raises(ValueError, match="setup_from_config"):
+            Job().save()
+        with pytest.raises(ValueError, match="setup_from_config"):
+            Job.get_saved("any-id")
+    finally:
+        _restore_memory_config()
 
 
-def test_durable_job_store_ok_after_setup(tmp_path, monkeypatch):
-    cfg = tmp_path / "durable-jobstore.yaml"
-    cfg.write_text(
-        "scheduler:\n"
-        "  jobStore:\n"
-        "    backend: postgres\n"
-        "    uri: postgresql+psycopg://postgres:example@localhost:5432/mock_pypepper\n"
-    )
-    reset_job_store()
-    config.mark_scheduler_job_store_applied()
-    config.load_config(str(cfg))
+def test_durable_job_store_ok_after_configure(tmp_path):
+    """Real configure clears deferred (no stub that self-marks)."""
+    cfg = _write_durable_cfg(tmp_path)
+    try:
+        config.load_config(str(cfg))
+        with pytest.raises(ValueError, match="setup_from_config"):
+            Job().save()
 
+        configure_job_store("memory")
+        job = Job()
+        job.save()
+        assert Job.get_saved(job.id) is not None
+    finally:
+        _restore_memory_config()
+
+
+def test_durable_job_store_ok_after_setup_from_config(tmp_path, monkeypatch):
+    """setup_from_config → configure_job_store clears deferred via set_job_store."""
+    cfg = _write_durable_cfg(tmp_path)
     import pypepper.scheduler.store as store_mod
 
     def _fake_configure(backend, **kwargs):
-        store_mod.set_job_store(InMemoryJobStore())
-        config.mark_scheduler_job_store_applied()
-        return store_mod.get_job_store()
+        assert backend == "postgres"
+        store = InMemoryJobStore()
+        store_mod.set_job_store(store)
+        return store
 
     monkeypatch.setattr(store_mod, "configure_job_store", _fake_configure)
-    setup_from_config(config.get_yml_config())
-    Job().save()
+    try:
+        config.load_config(str(cfg))
+        setup_from_config(config.get_yml_config())
+        assert config._deferred_durable_job_store_backend is None
+        Job().save()
+    finally:
+        _restore_memory_config()
 
 
-def test_load_config_memory_job_store_does_not_defer(monkeypatch):
-    warns: list[str] = []
-    monkeypatch.setattr(log, "warn", lambda msg, *a, **k: warns.append(str(msg)))
-    reset_job_store()
-    config.mark_scheduler_job_store_applied()
+def test_configure_before_load_does_not_false_positive(tmp_path):
+    """Non-memory store already installed: durable load must not block save."""
+    set_job_store(_NonMemoryStore())
+    cfg = _write_durable_cfg(tmp_path)
+    try:
+        config.load_config(str(cfg))
+        assert config._deferred_durable_job_store_backend == "postgres"
+        job = Job()
+        job.save()
+        assert Job.get_saved(job.id) is not None
+        assert config._deferred_durable_job_store_backend is None
+    finally:
+        _restore_memory_config()
+
+
+def test_reload_after_setup_clears_when_non_memory_installed(tmp_path):
+    set_job_store(_NonMemoryStore())
+    cfg = _write_durable_cfg(tmp_path)
+    try:
+        config.load_config(str(cfg))
+        Job().save()
+        config.load_config(str(cfg))
+        Job().save()
+    finally:
+        _restore_memory_config()
+
+
+def test_set_job_store_clears_deferred(tmp_path):
+    cfg = _write_durable_cfg(tmp_path)
+    try:
+        config.load_config(str(cfg))
+        set_job_store(InMemoryJobStore())
+        assert config._deferred_durable_job_store_backend is None
+        Job().save()
+    finally:
+        _restore_memory_config()
+
+
+def test_reset_job_store_rearms_deferred_fail_fast(tmp_path):
+    """reset must not allow silent memory persist while YAML still declares durable."""
+    cfg = _write_durable_cfg(tmp_path)
+    try:
+        config.load_config(str(cfg))
+        configure_job_store("memory")
+        Job().save()
+
+        reset_job_store()
+        assert config._deferred_durable_job_store_backend == "postgres"
+        with pytest.raises(ValueError, match="setup_from_config"):
+            Job().save()
+        with pytest.raises(ValueError, match="setup_from_config"):
+            Job.get_saved("x")
+    finally:
+        _restore_memory_config()
+
+
+def test_load_config_memory_job_store_does_not_defer():
     config.load_config("./conf/app.config.yaml")
     assert config._deferred_durable_job_store_backend is None
-    assert not any("jobStore" in w for w in warns)
     Job().save()

--- a/tests/common/test_common_config.py
+++ b/tests/common/test_common_config.py
@@ -1,6 +1,9 @@
+import pytest
+
 from pypepper.common.config import config
 from pypepper.common.log import log
-from pypepper.scheduler.store import get_job_store, reset_job_store
+from pypepper.scheduler.job import Job
+from pypepper.scheduler.store import get_job_store, reset_job_store, setup_from_config
 from pypepper.scheduler.store.memory import InMemoryJobStore
 
 
@@ -35,7 +38,6 @@ def test_load_config_does_not_configure_job_store(monkeypatch, tmp_path):
         lambda *a, **k: calls.append("configure_job_store"),
     )
 
-    # Durable backend in YAML would reconfigure the store if setup were wired back.
     cfg = tmp_path / "durable-jobstore.yaml"
     cfg.write_text(
         "scheduler:\n"
@@ -45,18 +47,45 @@ def test_load_config_does_not_configure_job_store(monkeypatch, tmp_path):
     )
 
     reset_job_store()
-    warns: list[str] = []
-    monkeypatch.setattr(log, "warn", lambda msg, *a, **k: warns.append(str(msg)))
+    config.mark_scheduler_job_store_applied()
     config.load_config(str(cfg))
 
     assert calls == []
     assert isinstance(get_job_store(), InMemoryJobStore)
-    assert any("setup_from_config" in w for w in warns)
+    with pytest.raises(ValueError, match="setup_from_config"):
+        Job().save()
 
 
-def test_load_config_memory_job_store_does_not_warn(monkeypatch):
+def test_durable_job_store_ok_after_setup(tmp_path, monkeypatch):
+    cfg = tmp_path / "durable-jobstore.yaml"
+    cfg.write_text(
+        "scheduler:\n"
+        "  jobStore:\n"
+        "    backend: postgres\n"
+        "    uri: postgresql+psycopg://postgres:example@localhost:5432/mock_pypepper\n"
+    )
+    reset_job_store()
+    config.mark_scheduler_job_store_applied()
+    config.load_config(str(cfg))
+
+    import pypepper.scheduler.store as store_mod
+
+    def _fake_configure(backend, **kwargs):
+        store_mod.set_job_store(InMemoryJobStore())
+        config.mark_scheduler_job_store_applied()
+        return store_mod.get_job_store()
+
+    monkeypatch.setattr(store_mod, "configure_job_store", _fake_configure)
+    setup_from_config(config.get_yml_config())
+    Job().save()
+
+
+def test_load_config_memory_job_store_does_not_defer(monkeypatch):
     warns: list[str] = []
     monkeypatch.setattr(log, "warn", lambda msg, *a, **k: warns.append(str(msg)))
     reset_job_store()
+    config.mark_scheduler_job_store_applied()
     config.load_config("./conf/app.config.yaml")
+    assert config._deferred_durable_job_store_backend is None
     assert not any("jobStore" in w for w in warns)
+    Job().save()

--- a/tests/common/test_common_security_crypto_digest.py
+++ b/tests/common/test_common_security_crypto_digest.py
@@ -1,20 +1,9 @@
-import hashlib
-
 import pytest
 
-from pypepper.common.log import log
 from pypepper.common.security.crypto import digest
 
 message = "1234567890"
 mock_hash_string = "c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646"
-mock_md5_abc = hashlib.md5(b"abc").hexdigest()
-
-
-@pytest.fixture(autouse=True)
-def _reset_weak_digest_warning():
-    digest.reset_weak_digest_warning()
-    yield
-    digest.reset_weak_digest_warning()
 
 
 def test_get():
@@ -28,31 +17,9 @@ def test_get_hex_str():
     assert result == mock_hash_string
 
 
-def test_strong_digest_does_not_warn(monkeypatch):
-    warns: list[str] = []
-    monkeypatch.setattr(log, "warn", lambda msg, *a, **k: warns.append(str(msg)))
-    digest.get(b"x", "sha256")
-    assert warns == []
-
-
-def test_weak_digest_warns_once(monkeypatch):
-    warns: list[str] = []
-    monkeypatch.setattr(log, "warn", lambda msg, *a, **k: warns.append(str(msg)))
-    digest.get(b"x", "md5")
-    digest.get(b"y", "SHA1")
-    assert len(warns) == 1
-    assert "md5" in warns[0]
-    assert "weak" in warns[0]
-
-
-def test_weak_digest_sha1_first_warn_message(monkeypatch):
-    warns: list[str] = []
-    monkeypatch.setattr(log, "warn", lambda msg, *a, **k: warns.append(str(msg)))
-    digest.get(b"x", "SHA1")
-    assert len(warns) == 1
-    assert "sha1" in warns[0]
-
-
-def test_weak_digest_still_returns_digest():
-    result = digest.get_hex_str(b"abc", "md5")
-    assert result == mock_md5_abc
+@pytest.mark.parametrize("alg", ["md5", "MD5", "sha1", "SHA1"])
+def test_weak_digest_rejected(alg: str):
+    with pytest.raises(ValueError, match="not allowed"):
+        digest.get(b"x", alg)
+    with pytest.raises(ValueError, match="not allowed"):
+        digest.get_hex_str(b"x", alg)

--- a/tests/common/test_common_security_crypto_elliptic.py
+++ b/tests/common/test_common_security_crypto_elliptic.py
@@ -1,8 +1,12 @@
 import pytest
 from cryptography.hazmat.primitives import serialization
 
-from pypepper.common.security.crypto.elliptic.algorithm import HashAlgorithmName
+from pypepper.common.security.crypto.elliptic.algorithm import (
+    HashAlgorithmName,
+    get_hash_algorithm,
+)
 from pypepper.common.security.crypto.elliptic.ecdsa import ecdsa
+from pypepper.exceptions import InternalException
 
 data = b"Hello, world!"
 
@@ -15,7 +19,7 @@ def test_ecdsa_sign_verify():
     private_key_pem = key.private_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.BestAvailableEncryption(b"Hello")
+        encryption_algorithm=serialization.BestAvailableEncryption(b"Hello"),
     )
     print("## [ECDSA] private_key_pem=", private_key_pem)
 
@@ -35,11 +39,17 @@ def test_ecdsa_sign_verify():
         data=data,
         certificate=public_key_pem,
         sig=sig,
-        hash_alg='SHA256',
+        hash_alg="SHA256",
     )
 
     assert result is True
 
 
-if __name__ == '__main__':
+@pytest.mark.parametrize("alg", ["md5", "sha1", "MD5", "SHA1"])
+def test_ecdsa_rejects_weak_hash(alg: str):
+    with pytest.raises(InternalException):
+        get_hash_algorithm(alg)
+
+
+if __name__ == "__main__":
     pytest.main()

--- a/tests/common/test_common_security_crypto_elliptic.py
+++ b/tests/common/test_common_security_crypto_elliptic.py
@@ -51,5 +51,11 @@ def test_ecdsa_rejects_weak_hash(alg: str):
         get_hash_algorithm(alg)
 
 
+@pytest.mark.parametrize("name", ["MD5", "SHA1"])
+def test_hash_algorithm_name_weak_attrs_removed(name: str):
+    with pytest.raises(AttributeError):
+        getattr(HashAlgorithmName, name)
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,20 @@
 import pytest
 
 from pypepper.common.cache import Cache
+from pypepper.common.config import config
 from pypepper.common.tracing import shutdown as tracing_shutdown
 from pypepper.loader import loader
 from pypepper.network.http.sse.connection import connection_manager
 from pypepper.network.http.sse.security import SSESecurityManager
 from pypepper.scheduler.channel import manager as channel_manager
 from pypepper.scheduler.store import reset_job_store
+
+
+def _reset_job_store_for_tests() -> None:
+    """Fresh memory store without carrying deferred durable YAML into the next test."""
+    reset_job_store()
+    # reset_job_store re-arms deferred from the last loaded YAML; clear for isolation.
+    config.mark_scheduler_job_store_applied()
 
 
 @pytest.fixture(autouse=True)
@@ -24,7 +32,7 @@ def _reset_global_registries():
     loader._module_loader_mapper.clear()
 
     # Scheduler job store
-    reset_job_store()
+    _reset_job_store_for_tests()
 
     # SSE rate-limit cache
     SSESecurityManager._rate_limit_cache = Cache(maxsize=1000, ttl=60)
@@ -35,7 +43,7 @@ def _reset_global_registries():
 
     tracing_shutdown()
 
-    reset_job_store()
+    _reset_job_store_for_tests()
 
     with connection_manager._lock:
         connection_manager._connections.clear()

--- a/tests/scheduler/test_cancel.py
+++ b/tests/scheduler/test_cancel.py
@@ -19,9 +19,13 @@ from pypepper.scheduler.workflow import Workflow
 
 @pytest.fixture(autouse=True)
 def _fresh_job_store():
+    from pypepper.common.config import config
+
     reset_job_store()
+    config.mark_scheduler_job_store_applied()
     yield
     reset_job_store()
+    config.mark_scheduler_job_store_applied()
 
 
 def _assert_cancelled(job: Job) -> None:

--- a/tests/scheduler/test_job_store_memory.py
+++ b/tests/scheduler/test_job_store_memory.py
@@ -23,9 +23,13 @@ from pypepper.scheduler.workflow import Workflow
 
 @pytest.fixture(autouse=True)
 def _fresh_job_store():
+    from pypepper.common.config import config
+
     reset_job_store()
+    config.mark_scheduler_job_store_applied()
     yield
     reset_job_store()
+    config.mark_scheduler_job_store_applied()
 
 
 def test_memory_put_get_list_delete():

--- a/uv.lock
+++ b/uv.lock
@@ -129,6 +129,15 @@ wheels = [
 ]
 
 [[package]]
+name = "boolean-py"
+version = "5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047, upload-time = "2025-04-03T10:39:49.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577, upload-time = "2025-04-03T10:39:48.449Z" },
+]
+
+[[package]]
 name = "build"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -142,6 +151,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2d/21/6ec54248b4d0d51f12f3ca4aa77a128077d747a5db86cb5a2fcd9aedecbd/build-1.5.1.tar.gz", hash = "sha256:94e17f1db803ab22f46049376c44c8437c52090f0dfdf1adc43df56542d644fb", size = 112439, upload-time = "2026-07-09T06:21:59.632Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/f7/2c3f99ff9282f1c1ec9f6298f2c03034658a0901eeacb3b3501cb488574c/build-1.5.1-py3-none-any.whl", hash = "sha256:f1a58fe2e5af5b0238a07b9e70207492c79ddebbdb1ad954fc86d62a56be3e0d", size = 31195, upload-time = "2026-07-09T06:21:58.551Z" },
+]
+
+[[package]]
+name = "cachecontrol"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msgpack" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f6/c972b32d80760fb79d6b9eeb0b3010a46b89c0b23cf6329417ff7886cd22/cachecontrol-0.14.4.tar.gz", hash = "sha256:e6220afafa4c22a47dd0badb319f84475d79108100d04e26e8542ef7d3ab05a1", size = 16150, upload-time = "2025-11-14T04:32:13.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/79/c45f2d53efe6ada1110cf6f9fca095e4ff47a0454444aefdde6ac4789179/cachecontrol-0.14.4-py3-none-any.whl", hash = "sha256:b7ac014ff72ee199b5f8af1de29d60239954f223e948196fa3d84adaffc71d2b", size = 22247, upload-time = "2025-11-14T04:32:11.733Z" },
+]
+
+[package.optional-dependencies]
+filecache = [
+    { name = "filelock" },
 ]
 
 [[package]]
@@ -515,6 +542,31 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclonedx-python-lib"
+version = "11.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "license-expression" },
+    { name = "packageurl-python" },
+    { name = "py-serializable" },
+    { name = "sortedcontainers" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/c9/5d0ccdd19bc7d8ab803b90695c1706aa2ea8529685d18e682dc2524d2630/cyclonedx_python_lib-11.11.0.tar.gz", hash = "sha256:4b3194db72b613717f2912447e67ab618c75ff7dcac6c4af3c0e9e1ac617c102", size = 1442983, upload-time = "2026-06-17T11:57:49.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/f3/56ccb2884aaa3db5622368e5191a3384b15f35392aa93df8b2f508c660d2/cyclonedx_python_lib-11.11.0-py3-none-any.whl", hash = "sha256:3049fc83e06a059b5c5907a527625a8ed5073caab10607ed4c9e5503b590fd44", size = 528689, upload-time = "2026-06-17T11:57:47.358Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -558,6 +610,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cd/95/d3f0ae10836324a2eab98a52b61210ac609f08200bf4bb0dc8132d32f78a/fastapi-0.139.2.tar.gz", hash = "sha256:333145a6891e9b5b3cfceb69baf817e8240cde4d4588ae5a10bf56ffacb6255e", size = 423428, upload-time = "2026-07-16T15:06:17.912Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/c7/cb03251d9dfb177246a9809a76f189d21df32dbd4a845951881d11323b7f/fastapi-0.139.2-py3-none-any.whl", hash = "sha256:b9ad015a835173d59865e2f5d8296fbc2b317bf56a2ba1a5bfbdd03de2fd4b1c", size = 130234, upload-time = "2026-07-16T15:06:19.557Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.31.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/55/1e19b2b56a24a4b94624f7e819e1bb87fa6c5609dbaf621df3aa6568a761/filelock-3.31.1.tar.gz", hash = "sha256:9e0c4e88ebe90833c1beafd3a547ccbc0bf7f491cd3858c3ec7aed63efe02163", size = 196656, upload-time = "2026-07-20T03:14:32.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/61/df1d9db18f188d0ae648956a1decadc0e3b77d0571474370fd01f28a82b1/filelock-3.31.1-py3-none-any.whl", hash = "sha256:9ea33146c780161bf67cb20c7cb26b651566820d65ad8dfdd79422602a2dcfc0", size = 97189, upload-time = "2026-07-20T03:14:31.307Z" },
 ]
 
 [[package]]
@@ -884,6 +945,18 @@ wheels = [
 ]
 
 [[package]]
+name = "license-expression"
+version = "30.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boolean-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl", hash = "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4", size = 120615, upload-time = "2025-07-22T11:13:31.217Z" },
+]
+
+[[package]]
 name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1162,6 +1235,79 @@ wheels = [
 ]
 
 [[package]]
+name = "msgpack"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/f9/c0a1c127f9049db9155afc316952ea571720dd01833ff5e4d7e8e6352dbb/msgpack-1.2.1.tar.gz", hash = "sha256:04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647", size = 183960, upload-time = "2026-06-18T16:13:52.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/16/f70100614b69feb3ade7285f08c9c52d6cda0a5c03f3f5e2facd63acb211/msgpack-1.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8c7b398c56ff125feae96c2737abfec5595f1fa0aa186df60c56040b8accb95c", size = 82926, upload-time = "2026-06-18T16:12:31.531Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/3c/08ecd5cdfe4e2de43aec79062028ad0f7b2d9b1fea5430068c198ba570da/msgpack-1.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1548006a91aa93c5da81f3bdcebc1a0d10cea2d25969754fbe848da622b2b895", size = 82730, upload-time = "2026-06-18T16:12:32.894Z" },
+    { url = "https://files.pythonhosted.org/packages/19/9f/a70c9cb1a04ecc134005149367dcfe35d167284e8f65035a1e4156ad17b5/msgpack-1.2.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1dabedcd0f23559f3596428c6589c1cd8c6eaed3a0d720795b07b0225d769203", size = 400729, upload-time = "2026-06-18T16:12:34.052Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7f/5ce020168cf0439041526e95aa068c722c016aee21624e331aeabeee2e8e/msgpack-1.2.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:83efa1c898e0fc5380fc0cabbf75164c52e3b5cbb45973710d75821928380c73", size = 407625, upload-time = "2026-06-18T16:12:35.239Z" },
+    { url = "https://files.pythonhosted.org/packages/79/70/fb7668ce0386819303047057aef6fc1da73b584291d9cff82b821744e2ef/msgpack-1.2.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:01e2dd6c9b19d333a00282330cc8a73d38d8dabc306dc5b42cd668c3ac82e833", size = 377891, upload-time = "2026-06-18T16:12:36.684Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/dc/9ebe654a73c3aed2e40aa6b52e3c2a02b5f53ef0085fa235a45d5b367f87/msgpack-1.2.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:350cb813d0af6e65d2f7ef0d729f7ff5be5a8bce03665892f43e5883d4ecc1b8", size = 391987, upload-time = "2026-06-18T16:12:37.839Z" },
+    { url = "https://files.pythonhosted.org/packages/42/eb/b67cf64218a2fa25e1c671fe1d3dbb06cbeb973e71bc4b822da079862d0b/msgpack-1.2.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:ee1d9ed27d0497b848923746cf762ed2e7db24f4be7eec8e5cbe8c766aa707b7", size = 374603, upload-time = "2026-06-18T16:12:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/2e/9ee200cde32fd1a0101b4006202fde554c1860adfb9bf7bff31ea4c08df8/msgpack-1.2.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:633727297ed063441fd1cda2288865487f33ad14eeb8831afb5f0c396a62cfce", size = 405121, upload-time = "2026-06-18T16:12:40.524Z" },
+    { url = "https://files.pythonhosted.org/packages/43/b6/f10117be7ca7a51e8feed699a907b8e663a8cd66e115ae6b4fb30cc7945c/msgpack-1.2.1-cp310-cp310-win32.whl", hash = "sha256:298872ecf9e61950f1c6af4ca969b859ee91783bb920ef6e6172697d0c8aad74", size = 64088, upload-time = "2026-06-18T16:12:41.762Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/93/89976c696fb0224662239d952c47b4d1661b34d79a332ef5584facaa8579/msgpack-1.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:2ff164c1b0bcb740b073b99e945234d0212852fa378e44a208c425379140dbeb", size = 70113, upload-time = "2026-06-18T16:12:42.78Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/6b/e9b1cdc042c4458801d2545ed782a95f3d6ba8e270cce8745b8603c7f748/msgpack-1.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:29a3f6e9667868429d8240dfd063ea5ffdc1321c13d783aa23827a38de0dcb22", size = 82812, upload-time = "2026-06-18T16:12:45.022Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/3a/dd518a1bf78ed1e9ad8afe57307c079a00eafe4b3068932a27ca1ea56b4f/msgpack-1.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:aded5bdf32609dc7987a49bbbd15a8ef096193f96dd8bbeb791de729e650acf5", size = 82739, upload-time = "2026-06-18T16:12:46.025Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e0/7ba9e1542bf0771a27b8b37c1316e3f95ae9d748fd765284655c476ad4ef/msgpack-1.2.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:146ee4e9ce80b365c6d4c47073da9da7bcec473e58194ceee5dd7620ace77e06", size = 414233, upload-time = "2026-06-18T16:12:47.029Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8d/671d81534ea0e2b0e8a121be100020da09eb78861fe3aa8f3ef7dcd3bed1/msgpack-1.2.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a28d076ca7c82b9c8728ad90b7147489449557038bed50e4241eb832395169b4", size = 423843, upload-time = "2026-06-18T16:12:48.19Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/b6/e5c737515ed1f166664b87601b532f58cbb73d8aa6a90b99f7c2c5037e8e/msgpack-1.2.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7d31c0ac0c640f877804c67cb2bc9f4e23dc2db97e96c2e67fa27d38283b41f8", size = 390772, upload-time = "2026-06-18T16:12:49.624Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/46/62ed8c2e87d7021eab19921594d961ef3aa3794eec76c716dc30f3bfd433/msgpack-1.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8ff92d7feeaf5bc26c51495b69e2f99ed97ab79346fb6555f44be7dd2ac6503b", size = 409559, upload-time = "2026-06-18T16:12:50.936Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/59aa3887b860bbf43532835e192b1c388a17590d6068ae4f8b2bc74c906e/msgpack-1.2.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:779197a6513bab3c3632265e3d0f7cb3227e62510841a6f34f1eaa37efbb345e", size = 387838, upload-time = "2026-06-18T16:12:52.161Z" },
+    { url = "https://files.pythonhosted.org/packages/09/11/f8563e471093420cf6478cb3271a0175d8402b82d879783d4035d2d03360/msgpack-1.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:67f6dd22fa72a93752643f07889796d62739a13415ee630169a8ce764f86cf9f", size = 421732, upload-time = "2026-06-18T16:12:53.556Z" },
+    { url = "https://files.pythonhosted.org/packages/57/cf/e673683c4c6c90c1022b24c65af4b03eda72b182a1176ef6449069d66acc/msgpack-1.2.1-cp311-cp311-win32.whl", hash = "sha256:91054a783328e0ea7954b8771095705c8d2243b814743fbaadf14552c9c52c5d", size = 64091, upload-time = "2026-06-18T16:12:54.821Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/07/ca212739d179f9083bff2c7c08c24101c3555a334fadc2b876b18768a3ae/msgpack-1.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2eda0b7ebb1283a98d3e4492ac933c8af6aff59fd3df1c3ed024f536af4b1dc8", size = 70462, upload-time = "2026-06-18T16:12:55.898Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/be/6798347b425e26f35db82e69dd83c09716c856a3714e7bffc4c0860fd830/msgpack-1.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:6ee967f7c7e1df2890c671ff2ee51a28ded0efc95da3e507176dee881ce36c66", size = 65059, upload-time = "2026-06-18T16:12:57.053Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/dd/9e8cbd8f5582ca4b590336f2b91ee5662f6a6ca562b565abaf696a0f81ff/msgpack-1.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2ef59c659f289eddf8aa6623823f19fa2f40a4029266889eac7a2505dd210c35", size = 83531, upload-time = "2026-06-18T16:12:58.249Z" },
+    { url = "https://files.pythonhosted.org/packages/50/2e/ebdb85a8da151397a2790363676b7ed7c125924fe618e4c6d8befb0cc62c/msgpack-1.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3567748a5107cb40cdf66a275430c2f87c07777698f4bfd25c35f44d533258c", size = 82657, upload-time = "2026-06-18T16:12:59.396Z" },
+    { url = "https://files.pythonhosted.org/packages/26/aa/753ad8b007b464e1d8aa0c8e650b9c5f4f725e658fc5ac8a7635c55b7f6e/msgpack-1.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60926b75d00c8e816ef98f3034f484a8bc64242d66839cef4cf7e503142316a0", size = 410634, upload-time = "2026-06-18T16:13:00.383Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fd/6adabd4f6d5e686f97dd02ce7fce3fe4cf672cbac36b8f67ff4040e8ad8b/msgpack-1.2.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:020e881a764b20d8d7ca1a54fc01b8175519d108e3c3f194fddc200bda95951a", size = 419989, upload-time = "2026-06-18T16:13:01.776Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cc/85039b7b0eb168aaad7383a23c97e291a11f08351cb45a606ce865e4e3f1/msgpack-1.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4202c74688ca06591f78cb18988228bd4cca2cc75d57b60008372892d2f1e6e6", size = 377544, upload-time = "2026-06-18T16:13:03.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/bf/35963899493b32030c85fc513b723ae66144ac70c11ebc52e889e16e3d99/msgpack-1.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8b267ce94efb76fbd1b3373511420074ee3187f0f7811bf394531de13294735a", size = 400842, upload-time = "2026-06-18T16:13:05.012Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/df/8e2ac970c8f99264cd9997d1c73df5466bc19da3301d7dc5500862a9b089/msgpack-1.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:e4f1d0f8f98ade9634e01fb704a408f9336c0a8f1117b369f5db83dc7551d8b1", size = 374108, upload-time = "2026-06-18T16:13:06.232Z" },
+    { url = "https://files.pythonhosted.org/packages/17/dd/fa8bd265110dfa51c20cb529f9e6d240a16fafe7e645004c6af2d01353ba/msgpack-1.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f02cf17a6ca1abe29b5f980644f7551f94d71f2011509b26d8625ce038f0df64", size = 414939, upload-time = "2026-06-18T16:13:07.478Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b9/8377a5ad8953fc0437c70cc98d9ae29f27fe5ac5109fbec0812085865735/msgpack-1.2.1-cp312-cp312-win32.whl", hash = "sha256:0c0d9802354507bcba62af19c17918e3eb437cc25e6f50657d511b5856a77aac", size = 64504, upload-time = "2026-06-18T16:13:08.822Z" },
+    { url = "https://files.pythonhosted.org/packages/57/7f/ce1e377df7e62461fefd9eb23bfb93a4a523f40a517b377b8f844d836828/msgpack-1.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c24aa15d5963051e1a5c62b12c50cd705992502b5ec1f3bece6046f33c9fc24", size = 71421, upload-time = "2026-06-18T16:13:09.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/32/ebfe84c9929f08f188d56c7a2fd913406a9ddad76a634697c1c43b8112e6/msgpack-1.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:4227224aaec8f7fbcbfbd4272319347b2bb4030366502600f8c45588c5187b07", size = 64775, upload-time = "2026-06-18T16:13:11.056Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ac/dcddcab6f6c20ecb387ca5e980371cdb3f87ff69aeca388be97eebc4c074/msgpack-1.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0a70e3cf2804a300d921bb0940426e35f4e489a23adfb77a808892241db0a064", size = 83151, upload-time = "2026-06-18T16:13:12.173Z" },
+    { url = "https://files.pythonhosted.org/packages/64/71/fbcfa83a1d6a9c6091942d1cfd070962244664b87427a9a49a6897b1b219/msgpack-1.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:491cc39455ca765fad51fb451bf2915eb2cf41192ab5801ce8d67c1d614fe056", size = 82351, upload-time = "2026-06-18T16:13:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/10/ddf7b06db879e8792d13934ddda09ff20bd2a583fd84c9b59aae9b0e650b/msgpack-1.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc", size = 407518, upload-time = "2026-06-18T16:13:14.233Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d3/36a46a8ed992b781acbc05928bd5bee3c810cb0c3563bf81a7b0c04a1a76/msgpack-1.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:787c9bebb5833e8f6fc8abca3c0597683d8d87f56a8842b6b89c75a5f3176e2d", size = 416405, upload-time = "2026-06-18T16:13:15.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/84/e8e9598b557c0ba6ddae901a73780a4c75ac667dddf59414b1e56a42fb34/msgpack-1.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dc871b997a9370d855b7394465f2f350e847a5b806dd38dcc9c989e7d87da155", size = 376257, upload-time = "2026-06-18T16:13:17.022Z" },
+    { url = "https://files.pythonhosted.org/packages/40/16/738fe6d875ad7e2a9429c165322a4ec088f4f273cdfae63d96a89c467961/msgpack-1.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:85f57e960d877f2977f6430896191b04a21f8901b3b4baf2e4604329f4db5402", size = 397469, upload-time = "2026-06-18T16:13:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/be/6d5952df75a7f24f35833af764c3a6860780364cb3a0030beb8099e1b2b4/msgpack-1.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1233ee2dd0cefba127583de50ea654677277047d238303521db35def3d7b2e7c", size = 372802, upload-time = "2026-06-18T16:13:19.685Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/39/e2ef7dbf0473bcb8dc7c50bf782a892d67414877b63e47fc88eb189ef5e6/msgpack-1.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e3dc2feb0876209d9c38aa56cb1de169bd6c4348f1aa48271f241226590993e6", size = 411273, upload-time = "2026-06-18T16:13:21.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c5/133f4512a56e983a93445c836c9d94d88f3bc2e0980ff4b9e577bd8416ce/msgpack-1.2.1-cp313-cp313-win32.whl", hash = "sha256:6d09badf350af2be9d189184e04e64cf54ad93569ab3d96fca58bd3e84aad707", size = 64471, upload-time = "2026-06-18T16:13:22.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/98/577e10b055096a7dd40732358cabaf7180a20c79ed1dcdbb618e4b9deac7/msgpack-1.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:33f14fba63278b714efe6ad07e50ea5f03d91537aa6a1c5f1ceca4cf44013ca9", size = 71274, upload-time = "2026-06-18T16:13:23.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ee/0c0048e7cfbef23c6a94791b8959ab28155232e7956de8a305b5ff588f05/msgpack-1.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc5febcd4c99effbc02b528e49d6fd0760b2b7d48c05239e345a5fa6e743d9a", size = 64795, upload-time = "2026-06-18T16:13:24.687Z" },
+    { url = "https://files.pythonhosted.org/packages/77/58/cce442852c6b9e1639c7c8ac8fd9143121cb32dab0f308df4d1426a8eb9c/msgpack-1.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:05f340e47e7e47d2da8db9b53e1bb1d294369e9ef45a747441309f6650b8351d", size = 83610, upload-time = "2026-06-18T16:13:25.724Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5c/15b4c7a0182f75ffa90751958ba36a9c01cafee367d49a3edc10ed140b01/msgpack-1.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:810b916696c86ef0deb3b74588480224df4c1b071136c34183e4a2a4284d7ac7", size = 83138, upload-time = "2026-06-18T16:13:26.781Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/99e58722feaffc5f2fbcc0c8c0d1451ab9f84097f7af87291b46af2390f4/msgpack-1.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ca0dacff965c47afdc3749a8469d7302a8f801d6a28758d55120d75e66ce6889", size = 406090, upload-time = "2026-06-18T16:13:28.072Z" },
+    { url = "https://files.pythonhosted.org/packages/19/03/8c63e8cf52958534ef688625965ab04c269a6cadd8caef16758b380a821a/msgpack-1.2.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e2bf9280bceb5efca998435904b5d3e9fdbcc11d90dc9df30aec7973252b720", size = 412106, upload-time = "2026-06-18T16:13:29.427Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d2/155d9e71b40e41fd934bc0c48b9b2770f22263e1ac20aad8e29fdca7be3f/msgpack-1.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa6c4be5d1c02a42b066ca6ddb71adf36432868fdcdb6ee87e634e86e0674190", size = 374851, upload-time = "2026-06-18T16:13:30.631Z" },
+    { url = "https://files.pythonhosted.org/packages/98/48/deaf2326262a8d5ea3295ce9649912ecd3f551ba7ec8e33c665d2ba583f3/msgpack-1.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec0e675d59150a6269ddc9139087c722292664a37d071a849c05c473350f1f2d", size = 396168, upload-time = "2026-06-18T16:13:31.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/2a/b4410f906c2ec0008f1608d3ab5143afc3ad3f4e6da0fed3ea2231d0bef4/msgpack-1.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:dd3bfe82d53edfe4b7fc9a7ec9761e23a7a5b1dac22264505af428253c29ed24", size = 371959, upload-time = "2026-06-18T16:13:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/59/86/1edc67270099a528fa2093ea60fe191233cd238e4bd30cfacf7db79fc959/msgpack-1.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5ad5467fc3f68b5468e06c5f788d712e9f8ffc8b0cd1bcb160c105c1ee92dae7", size = 408457, upload-time = "2026-06-18T16:13:34.567Z" },
+    { url = "https://files.pythonhosted.org/packages/82/90/8b630fef07d8c5ab457b71ff2c217910c83d333c7a68472c186e87cc504a/msgpack-1.2.1-cp314-cp314-win32.whl", hash = "sha256:98b58bdb89c46190e4609bb36abe17c6d4105ad13f9c5f8f6f64d320f8ced3fb", size = 65942, upload-time = "2026-06-18T16:13:36.056Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f1/467b81e98b24dd3885d7b1857728797b4ffc76a7a7483af4fb321a07de3c/msgpack-1.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:74847557e28ce71bd3c438a447ca90e4b507e997ddbdef8a12a7b283b86c156b", size = 72627, upload-time = "2026-06-18T16:13:37.079Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/1d/5d8c4c89985feb6acefb82a09e501c60392261856d2408d20bfe4f0360b1/msgpack-1.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:b50b727bd652bdc37d950336c848ef20ec54a4cafc38dce19b1cd86ad625d0f7", size = 66908, upload-time = "2026-06-18T16:13:38.23Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/02/ad2afb678b4de94496cd432b581759b756a92c1192d8c767edd6b132efdc/msgpack-1.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8d00f177ca88a77c1cf848d204a38f249751650b601cb6532acc68805d8a8273", size = 86000, upload-time = "2026-06-18T16:13:39.44Z" },
+    { url = "https://files.pythonhosted.org/packages/54/74/0b797484013128837f3b1cbb6cea019277c4de4e377dc512b4d9a0f92940/msgpack-1.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5bb9c386f0a329c035ddbab4b72d1028bf9627add8dda41070288563d57ed1b1", size = 86544, upload-time = "2026-06-18T16:13:40.447Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/b4/b774d7eb95561739907fec675582f83203cf41c597a418c2589b4bfb8e9d/msgpack-1.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20466cca18c49c7292a8984bc15d65857b171e7264bdcb5f96baf8be238791fc", size = 427661, upload-time = "2026-06-18T16:13:41.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f9/3243191dc9937e00756c8bc1b0272fed8f23758e43df2a3b46f533e5090f/msgpack-1.2.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:196300e7e5d6e74d50f1607ab9c06c4a1484c383cd22defd727902591f7e8dde", size = 426375, upload-time = "2026-06-18T16:13:42.936Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c7/1693111db9944ba4ad4b67a1e788400d78a0b6af7a6523dc7e4e58f8274b/msgpack-1.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:575957e79cd51903a4e8495a242442949641e08f1efd5197b43bebd3ea7682b4", size = 380495, upload-time = "2026-06-18T16:13:44.306Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2b/92f86956a0c13e8662f7e2ad630c4eb4db07497b967589bd5245e018b2c1/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8c2ed1e48cc0f460bf3c7780e7137ff21a4e18433451916f2442c1b21036cd7d", size = 410897, upload-time = "2026-06-18T16:13:45.629Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ea/1479f72d200313a76fc2f823a79d1e07ed052ab7b8a0280640aa7b95de42/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5f6277e5f783c36786a145e0247fc189a03f35f84b251646e53592d2bc12b355", size = 378519, upload-time = "2026-06-18T16:13:46.998Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/4d/fa006060ffa1011d32bfae826fe766fe73e02982183601633b7121058ab3/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f9389552ecf4784886345ead0647e4edc96bee37cbab05b75540f542f766c48c", size = 419815, upload-time = "2026-06-18T16:13:48.205Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/aab6c946570496b78e67804721f3d5e2d62a93081b9b37df77764ef56347/msgpack-1.2.1-cp314-cp314t-win32.whl", hash = "sha256:c1c79a604a2969a868a78b6ebd27a887e00c624f14f66b3038e0590cb23332d1", size = 70914, upload-time = "2026-06-18T16:13:49.385Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0a/e608956488a2af014cfe6e3d665e090b8ee42aa14b07f8f95b8880d66b09/msgpack-1.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f12038a35fabd52e56a3547bab42401af49a45caa6dd00b34c44de235bc93ee2", size = 77999, upload-time = "2026-06-18T16:13:50.467Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/8a/27e2e57055176e366a46b85d02d68e7a5bcfbdd8474c9706375d965f24d3/msgpack-1.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0adcf06ffde0777c0e1a9b771a2b1c4226ba1bbf748c8efcc02fcdeca3299107", size = 71160, upload-time = "2026-06-18T16:13:51.498Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1345,6 +1491,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packageurl-python"
+version = "0.17.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/d6/3b5a4e3cfaef7a53869a26ceb034d1ff5e5c27c814ce77260a96d50ab7bb/packageurl_python-0.17.6.tar.gz", hash = "sha256:1252ce3a102372ca6f86eb968e16f9014c4ba511c5c37d95a7f023e2ca6e5c25", size = 50618, upload-time = "2025-11-24T15:20:17.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/2f/c7277b7615a93f51b5fbc1eacfc1b75e8103370e786fd8ce2abf6e5c04ab/packageurl_python-0.17.6-py3-none-any.whl", hash = "sha256:31a85c2717bc41dd818f3c62908685ff9eebcb68588213745b14a6ee9e7df7c9", size = 36776, upload-time = "2025-11-24T15:20:16.962Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1378,6 +1533,52 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+]
+
+[[package]]
+name = "pip-api"
+version = "0.0.34"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pip" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/f1/ee85f8c7e82bccf90a3c7aad22863cc6e20057860a1361083cd2adacb92e/pip_api-0.0.34.tar.gz", hash = "sha256:9b75e958f14c5a2614bae415f2adf7eeb54d50a2cfbe7e24fd4826471bac3625", size = 123017, upload-time = "2024-07-09T20:32:30.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/f7/ebf5003e1065fd00b4cbef53bf0a65c3d3e1b599b676d5383ccb7a8b88ba/pip_api-0.0.34-py3-none-any.whl", hash = "sha256:8b2d7d7c37f2447373aa2cf8b1f60a2f2b27a84e1e9e0294a3f6ef10eb3ba6bb", size = 120369, upload-time = "2024-07-09T20:32:29.099Z" },
+]
+
+[[package]]
+name = "pip-audit"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachecontrol", extra = ["filecache"] },
+    { name = "cyclonedx-python-lib" },
+    { name = "packaging" },
+    { name = "pip-api" },
+    { name = "pip-requirements-parser" },
+    { name = "platformdirs" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tomli" },
+    { name = "tomli-w" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/a4/f21d5f0a0edabcbce31560b73c7c5a6f72ae87af4236fd1069c8f59a353d/pip_audit-2.10.1.tar.gz", hash = "sha256:1eb4565d19ebe5d48996f4b770b4d2b32887e12cb12cfa637f1a064011b55ffc", size = 54275, upload-time = "2026-06-10T22:17:01.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/a7/b0c504148114047bd1bc9d97447453c6850ca176bb2f3c0038835994e8b7/pip_audit-2.10.1-py3-none-any.whl", hash = "sha256:99ef3f600a317c1945f1e89e227ef26e1c2d618429b8bd3fa6f4f7c440c4611a", size = 62023, upload-time = "2026-06-10T22:17:00.309Z" },
+]
+
+[[package]]
+name = "pip-requirements-parser"
+version = "32.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/2a/63b574101850e7f7b306ddbdb02cb294380d37948140eecd468fae392b54/pip-requirements-parser-32.0.1.tar.gz", hash = "sha256:b4fa3a7a0be38243123cf9d1f3518da10c51bdb165a2b2985566247f9155a7d3", size = 209359, upload-time = "2022-12-21T15:25:22.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/d0/d04f1d1e064ac901439699ee097f58688caadea42498ec9c4b4ad2ef84ab/pip_requirements_parser-32.0.1-py3-none-any.whl", hash = "sha256:4659bc2a667783e7a15d190f6fccf8b2486685b6dba4c19c3876314769c57526", size = 35648, upload-time = "2022-12-21T15:25:21.046Z" },
 ]
 
 [[package]]
@@ -1491,6 +1692,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/2c/c1547871be3790676e8868b38655496422f94f0978dfb66b74bdba2f1676/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6b9016b1714da4dd5ecaaa75b82098aa5a0b87854ce9b092e21c27c4ae23e014", size = 3946204, upload-time = "2026-05-01T23:31:39.626Z" },
     { url = "https://files.pythonhosted.org/packages/c4/b1/f6670f00fa7ea601584623f6c11602ab92117d83eaff885e0210f6de7418/psycopg_binary-3.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:47c656a8a7ba6eb0cff1801a4caaa9c8bdc12d03080e273aff1c8ac39971a77e", size = 4255811, upload-time = "2026-05-01T23:31:44.986Z" },
     { url = "https://files.pythonhosted.org/packages/eb/e6/5fff07a70d1f945ed90ae131c3bd76cab32beff7c58c6db15ad5820b6d1f/psycopg_binary-3.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:c37e024c07308cd06cf3ec51bfd0e7f6157585a4d84d1bce4a7f5f7913719bf8", size = 3666849, upload-time = "2026-05-01T23:31:51.165Z" },
+]
+
+[[package]]
+name = "py-serializable"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368, upload-time = "2025-07-21T09:56:48.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl", hash = "sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304", size = 23045, upload-time = "2025-07-21T09:56:46.848Z" },
 ]
 
 [[package]]
@@ -1738,6 +1951,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
 name = "pypepper"
 version = "0.6.2"
 source = { editable = "." }
@@ -1770,6 +1992,7 @@ dev = [
     { name = "mypy" },
     { name = "packaging" },
     { name = "pip" },
+    { name = "pip-audit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1808,6 +2031,7 @@ dev = [
     { name = "mypy", specifier = "==2.3.0" },
     { name = "packaging", specifier = "==26.2" },
     { name = "pip", specifier = "==26.1.2" },
+    { name = "pip-audit", specifier = "==2.10.1" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-asyncio", specifier = "==1.4.0" },
     { name = "pytest-cov", specifier = "==7.1.0" },
@@ -2102,6 +2326,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.51"
 source = { registry = "https://pypi.org/simple" }
@@ -2220,6 +2453,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1739,7 +1739,7 @@ wheels = [
 
 [[package]]
 name = "pypepper"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "arrow" },


### PR DESCRIPTION
## Summary

- Problem: R8 residual eng polish — unpinned `pip-audit`, weak digests still accepted (warn-only), durable `jobStore` forgetfulness only warned, coverage ignored branches.
- Why it matters: Hardens supply-chain reproducibility, crypto defaults, and scheduler config footguns without waiting for a separate major-only pass.
- What changed: Pin `pip-audit==2.10.1`; reject `md5`/`sha1` in digest (`ValueError`) and ECDSA (`HashAlgorithmName` removed → `InternalException`); deferred durable jobStore makes `Job.save`/`get_saved` raise until `setup_from_config`; `coverage` `branch = true` with `fail_under` 90.
- What did NOT change: SSE auth-off; Trusted Publisher; Dependabot Docker pins from P3. Package version is **0.6.2** (no tag/publish in this PR).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] common
- [ ] event
- [ ] fsm
- [ ] helper
- [ ] network
- [x] scheduler
- [x] CI/CD / infra

## Linked Issue/PR

- Related R8 eng polish / post-#38 residuals

## User-visible / Behavior Changes

- **Breaking:** `digest.get` / `get_hex_str` reject `md5`/`sha1`.
- **Breaking:** ECDSA no longer defines/accepts MD5/SHA1.
- **Breaking:** After `load_config` with non-`memory` `scheduler.jobStore.backend`, `Job.save` / `Job.get_saved` raise `ValueError` until `setup_from_config` (or `configure_job_store`).
- CI/`make audit` installs pinned `pip-audit==2.10.1`.
- Coverage reports include branch coverage (gate still 90%).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No` — audit still queries advisory data as before, pinned auditor)
- Command/tool execution surface changed? (`Yes` — `make audit`/CI pin `pip-audit==2.10.1`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: Auditor version locked to reduce floating-tool supply-chain drift.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local `.venv`
- Relevant config (redacted): N/A

### Steps

1. `make check && make test && make docs && make audit`
2. Confirm `digest.get(b"x", "md5")` raises `ValueError`
3. Confirm durable YAML without setup → `Job().save()` raises `ValueError`

### Expected

- All gates pass; branch coverage ≥90%; audit clean

### Actual

- `make check` / `make docs` / `make audit` OK
- `make test`: 229 passed, coverage **92.10%** (branch=true)

## Evidence

- [x] Failing test/log before + passing after (digest reject + durable save tests)
- [x] Trace/log snippets (local pytest + audit “No known vulnerabilities found”)

## Human Verification (required)

- Verified scenarios: pin install path; digest/ECDSA rejects; deferred jobStore → save fail then OK after stubbed setup; branch cov gate
- Edge cases checked: memory backend still loads/saves; case-insensitive md5/SHA1
- What you did **not** verify: live GitHub Actions on this PR (pending CI)

## Compatibility / Migration

- Backward compatible? (`No` — breaking crypto + jobStore fail-fast)
- Config/env changes? (`No` — behavior change for existing durable YAML apps that forgot setup)
- Migration needed? (`Yes`)
- If yes, exact upgrade steps:
  1. Stop using `md5`/`sha1` with digest/ECDSA; switch to `sha256+`.
  2. After `load_config` with durable `jobStore`, always call `setup_from_config` before `Job.save` / `scheduled()`.
  3. Release tag will be **v0.6.2** when you choose to publish (not part of this PR).

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR
- Files/config to restore: `digest.py`, `elliptic/algorithm.py`, `config.py` / `job.py` deferred checks
- Known bad symptoms: apps using md5/sha1 crash; durable YAML apps that never called setup now fail on first save

## Risks and Mitigations

- Risk: Callers still on md5/sha1 break at runtime
  - Mitigation: CHANGELOG Breaking + guide; clear `ValueError` / `InternalException`
- Risk: Deferred check only on `save`/`get_saved` (not `load_config`) so load→setup order still works
  - Mitigation: Documented; tests cover fail-then-setup path
