### PR TITLE
feat(scheduler): wire Task round/retry fields in Workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - `Task.retry_until_max` (default 1000): per-round attempt cap when `retry_until_completed=True` and `retry_count==0`.
+- `Task` rejects negative `retry_count` / `retry_delay`.
 
 ### Changed
 - `Workflow` now honors `round_times`, `round_timeout` (soft per-execute timeout in seconds; orphaned work may overlap retries), and `retry_until_completed` with `retry_count` / `retry_until_max`. Previously these fields were stored but unused.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ## Unreleased
 
 ### Added
-- `Task.retry_until_max` (default 1000): hard cap when `retry_until_completed=True` and `retry_count==0`.
+- `Task.retry_until_max` (default 1000): per-round attempt cap when `retry_until_completed=True` and `retry_count==0`.
 
 ### Changed
-- `Workflow` now honors `round_times`, `round_timeout` (soft per-execute timeout in seconds), and `retry_until_completed` (A3 with `retry_count` / `retry_until_max`). Previously these fields were stored but unused.
+- `Workflow` now honors `round_times`, `round_timeout` (soft per-execute timeout in seconds; orphaned work may overlap retries), and `retry_until_completed` with `retry_count` / `retry_until_max`. Previously these fields were stored but unused.
 
 ## 0.6.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Changed
 - `Workflow` now honors `round_times`, `round_timeout` (soft per-execute timeout in seconds; orphaned work may overlap retries), and `retry_until_completed` with `retry_count` / `retry_until_max`. Previously these fields were stored but unused.
 
+### Fixed
+- Soft `round_timeout`: if the worker finishes successfully in the wait-timeout race window, return its result instead of re-raising `TimeoutError`.
+
 ## 0.6.2
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+- `Task.retry_until_max` (default 1000): hard cap when `retry_until_completed=True` and `retry_count==0`.
+
+### Changed
+- `Workflow` now honors `round_times`, `round_timeout` (soft per-execute timeout in seconds), and `retry_until_completed` (A3 with `retry_count` / `retry_until_max`). Previously these fields were stored but unused.
+
 ## 0.6.2
 
 ### Breaking

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@
 # IMAGE_TAG when bumping by hand. UV_IMAGE stays ARG-indirect (not the
 # primary Dependabot target). Dependabot cannot update ARG-interpolated FROM.
 
-ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.29
+ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.30
 
 FROM ${UV_IMAGE} AS uvbin
 

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -72,10 +72,10 @@ only stops the consumer loop; it is not job cancel.
 | Field | Behavior |
 |-------|----------|
 | `retry_count` / `retry_delay` | Inner attempts per round: up to `retry_count + 1`, with delay between failures |
-| `retry_until_completed` | When `True` and `retry_count == 0`, retry until success up to `retry_until_max` (default 1000). When `True` and `retry_count > 0`, `retry_count` is the cap (`count + 1` attempts); `retry_until_max` is ignored |
-| `retry_until_max` | Hard cap for until-retries (`>= 1`); only applies when until + `retry_count == 0` |
-| `round_times` | Outer rounds (default 1); each round gets a fresh inner retry budget |
-| `round_timeout` | Soft timeout in **seconds** for a single `execute` call (`0` = none). Uses a worker future; timeout counts as a failed attempt (thread is not killed) |
+| `retry_until_completed` | When `True` and `retry_count == 0`, retry until success up to `retry_until_max` (default 1000) **per round**. When `True` and `retry_count > 0`, `retry_count` is the cap (`count + 1` attempts); `retry_until_max` is ignored |
+| `retry_until_max` | Per-round attempt cap for until-retries (`>= 1`); only when until + `retry_count == 0`. Not a global cap across `round_times` |
+| `round_times` | Outer rounds (default 1); each round gets a fresh inner retry budget. No delay between rounds |
+| `round_timeout` | Soft timeout in **seconds** for a single `execute` call (`0` = none). Timeout counts as a failed attempt; the worker thread is **not** killed and may overlap the next attempt. Prefer idempotent executors |
 | `optional` | Failed optional tasks continue the workflow |
 
 Non-optional task failure after all rounds/attempts aborts the workflow.

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -65,21 +65,20 @@ skips work if the job is already cancelled, and stops before `COMPLETE` at workf
 boundaries. It does **not** interrupt a sync workflow mid-`to_thread`. `Channel.stop`
 only stops the consumer loop; it is not job cancel.
 
-## Workflow retries
+## Workflow retries and rounds
 
-`Workflow.run()` executes tasks sequentially and respects:
+`Workflow.run()` executes tasks sequentially. Per task:
 
-- `retry_count` / `retry_delay`
-- `optional` (failed optional tasks continue the workflow)
+| Field | Behavior |
+|-------|----------|
+| `retry_count` / `retry_delay` | Inner attempts per round: up to `retry_count + 1`, with delay between failures |
+| `retry_until_completed` | When `True` and `retry_count == 0`, retry until success up to `retry_until_max` (default 1000). When `True` and `retry_count > 0`, `retry_count` is the cap (`count + 1` attempts); `retry_until_max` is ignored |
+| `retry_until_max` | Hard cap for until-retries (`>= 1`); only applies when until + `retry_count == 0` |
+| `round_times` | Outer rounds (default 1); each round gets a fresh inner retry budget |
+| `round_timeout` | Soft timeout in **seconds** for a single `execute` call (`0` = none). Uses a worker future; timeout counts as a failed attempt (thread is not killed) |
+| `optional` | Failed optional tasks continue the workflow |
 
-!!! warning "Fields not wired yet"
-    These attributes exist on `Task` / `IBase` but are **not** used by `Workflow._run_task`:
-
-    - `retry_until_completed`
-    - `round_timeout`
-    - `round_times`
-
-    Prefer `retry_count` / `retry_delay` / `optional` until those semantics land.
+Non-optional task failure after all rounds/attempts aborts the workflow.
 
 ## Persistence
 

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -71,11 +71,11 @@ only stops the consumer loop; it is not job cancel.
 
 | Field | Behavior |
 |-------|----------|
-| `retry_count` / `retry_delay` | Inner attempts per round: up to `retry_count + 1`, with delay between failures |
+| `retry_count` / `retry_delay` | When until is false, or until + `retry_count > 0`: up to `retry_count + 1` attempts per round, with `retry_delay` seconds between failures. When until + `retry_count == 0`, the attempt budget is `retry_until_max` instead (see below). Both must be `>= 0` |
 | `retry_until_completed` | When `True` and `retry_count == 0`, retry until success up to `retry_until_max` (default 1000) **per round**. When `True` and `retry_count > 0`, `retry_count` is the cap (`count + 1` attempts); `retry_until_max` is ignored |
 | `retry_until_max` | Per-round attempt cap for until-retries (`>= 1`); only when until + `retry_count == 0`. Not a global cap across `round_times` |
-| `round_times` | Outer rounds (default 1); each round gets a fresh inner retry budget. No delay between rounds |
-| `round_timeout` | Soft timeout in **seconds** for a single `execute` call (`0` = none). Timeout counts as a failed attempt; the worker thread is **not** killed and may overlap the next attempt. Prefer idempotent executors |
+| `round_times` | Outer rounds (default 1); each round gets a fresh inner retry budget. Success returns early; later rounds run only after a full failed inner budget. No delay between rounds |
+| `round_timeout` | Soft timeout in **seconds** for a single `execute` call (`0` = none). Timeout counts as a failed attempt; the worker thread is **not** killed and may overlap the next attempt. Prefer idempotent executors. Many until-retries with a short timeout can pile non-daemon threads |
 | `optional` | Failed optional tasks continue the workflow |
 
 Non-optional task failure after all rounds/attempts aborts the workflow.

--- a/pypepper/scheduler/base.py
+++ b/pypepper/scheduler/base.py
@@ -19,7 +19,9 @@ class IBase(metaclass=ABCMeta):
     updated: str
     tags: list[Tag]
     progress: float = 0
+    # Seconds per execute attempt when wired by Workflow (0 = no timeout).
     round_timeout: int = 0
+    # Outer execution rounds per task (each round has its own retry budget).
     round_times: int = 1
     version: int = 1
     context: Context

--- a/pypepper/scheduler/task.py
+++ b/pypepper/scheduler/task.py
@@ -48,6 +48,10 @@ class Task(ITask):
             raise ValueError(f"round_times must be >= 1, got {round_times}")
         if round_timeout < 0:
             raise ValueError(f"round_timeout must be >= 0, got {round_timeout}")
+        if retry_count < 0:
+            raise ValueError(f"retry_count must be >= 0, got {retry_count}")
+        if retry_delay < 0:
+            raise ValueError(f"retry_delay must be >= 0, got {retry_delay}")
 
         self.channel_id = channel_id
         self.dag_id = dag_id
@@ -57,7 +61,7 @@ class Task(ITask):
         self.description = description
         self.tags = tags
         self.executor = executor
-        # Seconds per execute attempt; 0 = no timeout (soft; orphaned work may overlap).
+        # Seconds per execute attempt; 0 = no timeout. Soft orphan/overlap only when > 0.
         self.round_timeout = round_timeout
         # Outer rounds; each round has its own inner retry budget.
         self.round_times = round_times

--- a/pypepper/scheduler/task.py
+++ b/pypepper/scheduler/task.py
@@ -8,7 +8,7 @@ from pypepper.scheduler.base import IBase
 from pypepper.scheduler.executor import Executor
 from pypepper.scheduler.tag import Tag
 
-# Default hard cap when retry_until_completed=True and retry_count==0.
+# Default per-round attempt cap when retry_until_completed=True and retry_count==0.
 DEFAULT_RETRY_UNTIL_MAX = 1000
 
 
@@ -16,7 +16,7 @@ class ITask(IBase, metaclass=ABCMeta):
     retry_count: int = 0
     retry_delay: int = 0
     retry_until_completed: bool = False
-    # Cap for until-retries when retry_count==0 (see Workflow._run_task).
+    # Per-round cap for until-retries when retry_count==0 (see Workflow._run_task).
     retry_until_max: int = DEFAULT_RETRY_UNTIL_MAX
     optional: bool = False
     executor: Executor
@@ -57,14 +57,14 @@ class Task(ITask):
         self.description = description
         self.tags = tags
         self.executor = executor
-        # Seconds per execute attempt; 0 = no timeout (soft timeout via Workflow).
+        # Seconds per execute attempt; 0 = no timeout (soft; orphaned work may overlap).
         self.round_timeout = round_timeout
         # Outer rounds; each round has its own inner retry budget.
         self.round_times = round_times
         self.version = version
         self.retry_count = retry_count
         self.retry_delay = retry_delay
-        # When True and retry_count==0, retry until success up to retry_until_max.
+        # When True and retry_count==0, retry until success up to retry_until_max per round.
         self.retry_until_completed = retry_until_completed
         self.retry_until_max = retry_until_max
         self.optional = optional

--- a/pypepper/scheduler/task.py
+++ b/pypepper/scheduler/task.py
@@ -8,11 +8,16 @@ from pypepper.scheduler.base import IBase
 from pypepper.scheduler.executor import Executor
 from pypepper.scheduler.tag import Tag
 
+# Default hard cap when retry_until_completed=True and retry_count==0.
+DEFAULT_RETRY_UNTIL_MAX = 1000
+
 
 class ITask(IBase, metaclass=ABCMeta):
     retry_count: int = 0
     retry_delay: int = 0
     retry_until_completed: bool = False
+    # Cap for until-retries when retry_count==0 (see Workflow._run_task).
+    retry_until_max: int = DEFAULT_RETRY_UNTIL_MAX
     optional: bool = False
     executor: Executor
 
@@ -34,8 +39,16 @@ class Task(ITask):
         retry_count: int = 0,
         retry_delay: int = 0,
         retry_until_completed: bool = False,
+        retry_until_max: int = DEFAULT_RETRY_UNTIL_MAX,
         optional: bool = False,
     ) -> None:
+        if retry_until_max < 1:
+            raise ValueError(f"retry_until_max must be >= 1, got {retry_until_max}")
+        if round_times < 1:
+            raise ValueError(f"round_times must be >= 1, got {round_times}")
+        if round_timeout < 0:
+            raise ValueError(f"round_timeout must be >= 0, got {round_timeout}")
+
         self.channel_id = channel_id
         self.dag_id = dag_id
         self.fingerprint = fingerprint
@@ -44,12 +57,16 @@ class Task(ITask):
         self.description = description
         self.tags = tags
         self.executor = executor
+        # Seconds per execute attempt; 0 = no timeout (soft timeout via Workflow).
         self.round_timeout = round_timeout
+        # Outer rounds; each round has its own inner retry budget.
         self.round_times = round_times
         self.version = version
         self.retry_count = retry_count
         self.retry_delay = retry_delay
+        # When True and retry_count==0, retry until success up to retry_until_max.
         self.retry_until_completed = retry_until_completed
+        self.retry_until_max = retry_until_max
         self.optional = optional
         self.id = uuid.new_uuid()
         self.context = Context(context_id=uuid.new_uuid())

--- a/pypepper/scheduler/workflow.py
+++ b/pypepper/scheduler/workflow.py
@@ -38,11 +38,12 @@ class Workflow(IWorkflow):
 
         Per task:
         - ``round_times`` outer rounds (default 1); each round has its own retry budget.
+          Success returns early; later rounds run only after a full failed inner budget.
         - ``round_timeout`` seconds soft-timeout per execute attempt (0 = none). Timed-out
           work may keep running in a background thread; the next attempt can overlap.
-        - ``retry_count`` / ``retry_delay`` / ``retry_until_completed`` / ``retry_until_max``:
-          until+count0 uses per-round ``retry_until_max``; until+count>0 caps at count+1;
-          until false uses count+1 as before.
+          Many until-retries with a short timeout can pile non-daemon threads.
+        - Retry modes: until false → ``retry_count + 1``; until + count 0 → per-round
+          ``retry_until_max``; until + count > 0 → ``retry_count + 1`` (max ignored).
         - ``optional``: failed optional tasks continue the workflow.
 
         Non-optional task failure aborts the workflow.

--- a/pypepper/scheduler/workflow.py
+++ b/pypepper/scheduler/workflow.py
@@ -10,9 +10,9 @@ from typing import cast
 
 from pypepper.common.log import log
 from pypepper.scheduler.base import IBase
-from pypepper.scheduler.task import DEFAULT_RETRY_UNTIL_MAX, Task
+from pypepper.scheduler.task import Task
 
-__all__ = ["DEFAULT_RETRY_UNTIL_MAX", "IWorkflow", "Workflow"]
+__all__ = ["IWorkflow", "Workflow"]
 
 
 class IWorkflow(IBase, metaclass=ABCMeta):
@@ -38,10 +38,11 @@ class Workflow(IWorkflow):
 
         Per task:
         - ``round_times`` outer rounds (default 1); each round has its own retry budget.
-        - ``round_timeout`` seconds soft-timeout per execute attempt (0 = none).
-        - ``retry_count`` / ``retry_delay`` / ``retry_until_completed`` / ``retry_until_max``
-          (A3): until+count0 uses ``retry_until_max``; until+count>0 caps at count+1;
-          until false uses count+1 as today.
+        - ``round_timeout`` seconds soft-timeout per execute attempt (0 = none). Timed-out
+          work may keep running in a background thread; the next attempt can overlap.
+        - ``retry_count`` / ``retry_delay`` / ``retry_until_completed`` / ``retry_until_max``:
+          until+count0 uses per-round ``retry_until_max``; until+count>0 caps at count+1;
+          until false uses count+1 as before.
         - ``optional``: failed optional tasks continue the workflow.
 
         Non-optional task failure aborts the workflow.
@@ -61,9 +62,7 @@ class Workflow(IWorkflow):
     @staticmethod
     def _attempts_per_round(task: Task) -> int:
         retry_count = int(task.retry_count or 0)
-        if task.retry_until_completed:
-            if retry_count > 0:
-                return max(1, retry_count + 1)
+        if task.retry_until_completed and retry_count == 0:
             return max(1, int(task.retry_until_max))
         return max(1, retry_count + 1)
 
@@ -77,14 +76,25 @@ class Workflow(IWorkflow):
         if timeout <= 0:
             return cast(object | None, executor.execute(task, task.context))
 
-        with ThreadPoolExecutor(max_workers=1) as pool:
-            future = pool.submit(executor.execute, task, task.context)
-            try:
-                return cast(object | None, future.result(timeout=timeout))
-            except FuturesTimeoutError as e:
+        # Soft timeout: do not wait for the worker on shutdown so TimeoutError fails
+        # fast and retries can proceed while orphaned work may still run.
+        pool = ThreadPoolExecutor(max_workers=1)
+        future = pool.submit(executor.execute, task, task.context)
+        try:
+            return cast(object | None, future.result(timeout=timeout))
+        except FuturesTimeoutError as e:
+            # On 3.10+, FuturesTimeoutError is TimeoutError. Only wrap wait timeouts;
+            # if the worker already finished, re-raise its exception.
+            if not future.done():
                 raise TimeoutError(
                     f"Task execute exceeded round_timeout={timeout}s: id={task.id}, name={task.name}"
                 ) from e
+            worker_exc = future.exception()
+            if worker_exc is not None:
+                raise worker_exc from None
+            raise
+        finally:
+            pool.shutdown(wait=False, cancel_futures=False)
 
     def _run_task(self, task: Task) -> object | None:
         rounds = max(1, int(task.round_times or 1))

--- a/pypepper/scheduler/workflow.py
+++ b/pypepper/scheduler/workflow.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import time
 from abc import ABCMeta
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import cast
 
 from pypepper.common.log import log
 from pypepper.scheduler.base import IBase
-from pypepper.scheduler.task import Task
+from pypepper.scheduler.task import DEFAULT_RETRY_UNTIL_MAX, Task
+
+__all__ = ["DEFAULT_RETRY_UNTIL_MAX", "IWorkflow", "Workflow"]
 
 
 class IWorkflow(IBase, metaclass=ABCMeta):
@@ -31,7 +35,15 @@ class Workflow(IWorkflow):
     def run(self) -> list[object]:
         """
         Sequentially execute tasks.
-        Respects retry_count / retry_delay / optional.
+
+        Per task:
+        - ``round_times`` outer rounds (default 1); each round has its own retry budget.
+        - ``round_timeout`` seconds soft-timeout per execute attempt (0 = none).
+        - ``retry_count`` / ``retry_delay`` / ``retry_until_completed`` / ``retry_until_max``
+          (A3): until+count0 uses ``retry_until_max``; until+count>0 caps at count+1;
+          until false uses count+1 as today.
+        - ``optional``: failed optional tasks continue the workflow.
+
         Non-optional task failure aborts the workflow.
         """
         from pypepper.common.tracing import get_tracer
@@ -46,21 +58,51 @@ class Workflow(IWorkflow):
                 results.append(result)
             return results
 
+    @staticmethod
+    def _attempts_per_round(task: Task) -> int:
+        retry_count = int(task.retry_count or 0)
+        if task.retry_until_completed:
+            if retry_count > 0:
+                return max(1, retry_count + 1)
+            return max(1, int(task.retry_until_max))
+        return max(1, retry_count + 1)
+
+    @staticmethod
+    def _execute_once(task: Task) -> object | None:
+        executor = task.executor
+        if executor is None:
+            return None
+
+        timeout = int(task.round_timeout or 0)
+        if timeout <= 0:
+            return cast(object | None, executor.execute(task, task.context))
+
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(executor.execute, task, task.context)
+            try:
+                return cast(object | None, future.result(timeout=timeout))
+            except FuturesTimeoutError as e:
+                raise TimeoutError(
+                    f"Task execute exceeded round_timeout={timeout}s: id={task.id}, name={task.name}"
+                ) from e
+
     def _run_task(self, task: Task) -> object | None:
-        attempts = max(1, int(task.retry_count or 0) + 1)
+        rounds = max(1, int(task.round_times or 1))
+        attempts = self._attempts_per_round(task)
         last_error: Exception | None = None
 
-        for attempt in range(attempts):
-            try:
-                executor = task.executor
-                if executor is None:
-                    return None
-                return cast(object | None, executor.execute(task, task.context))
-            except Exception as e:
-                last_error = e
-                log.warn(f"Task failed: id={task.id}, name={task.name}, attempt={attempt + 1}/{attempts}, error={e}")
-                if attempt + 1 < attempts and task.retry_delay:
-                    time.sleep(task.retry_delay)
+        for round_idx in range(rounds):
+            for attempt in range(attempts):
+                try:
+                    return self._execute_once(task)
+                except Exception as e:
+                    last_error = e
+                    log.warn(
+                        f"Task failed: id={task.id}, name={task.name}, "
+                        f"round={round_idx + 1}/{rounds}, attempt={attempt + 1}/{attempts}, error={e}"
+                    )
+                    if attempt + 1 < attempts and task.retry_delay:
+                        time.sleep(task.retry_delay)
 
         if task.optional:
             log.warn(f"Optional task failed, continuing: id={task.id}, error={last_error}")

--- a/pypepper/scheduler/workflow.py
+++ b/pypepper/scheduler/workflow.py
@@ -83,16 +83,11 @@ class Workflow(IWorkflow):
         try:
             return cast(object | None, future.result(timeout=timeout))
         except FuturesTimeoutError as e:
-            # On 3.10+, FuturesTimeoutError is TimeoutError. Only wrap wait timeouts;
-            # if the worker already finished, re-raise its exception.
-            if not future.done():
-                raise TimeoutError(
-                    f"Task execute exceeded round_timeout={timeout}s: id={task.id}, name={task.name}"
-                ) from e
-            worker_exc = future.exception()
-            if worker_exc is not None:
-                raise worker_exc from None
-            raise
+            # On 3.10+, FuturesTimeoutError is TimeoutError. If the worker finished in
+            # the race window, return/raise its outcome; otherwise wrap the wait timeout.
+            if future.done():
+                return cast(object | None, future.result())
+            raise TimeoutError(f"Task execute exceeded round_timeout={timeout}s: id={task.id}, name={task.name}") from e
         finally:
             pool.shutdown(wait=False, cancel_futures=False)
 

--- a/tests/scheduler/test_workflow.py
+++ b/tests/scheduler/test_workflow.py
@@ -216,3 +216,166 @@ def test_task_rejects_invalid_retry_until_max():
 def test_task_rejects_invalid_round_times():
     with pytest.raises(ValueError, match="round_times"):
         _task("bad", Executor(), round_times=0)
+
+
+def test_task_rejects_negative_round_timeout():
+    with pytest.raises(ValueError, match="round_timeout"):
+        _task("bad", Executor(), round_timeout=-1)
+
+
+def test_workflow_classic_retry_count_and_delay(monkeypatch):
+    calls = {"n": 0}
+    delays: list[float] = []
+
+    def flaky(task, context):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise RuntimeError(f"fail-{calls['n']}")
+        return "ok"
+
+    def track_sleep(seconds):
+        delays.append(seconds)
+
+    monkeypatch.setattr(time, "sleep", track_sleep)
+
+    task = _task(
+        "classic",
+        CallableExecutor(flaky),
+        retry_count=2,
+        retry_delay=7,
+        retry_until_completed=False,
+    )
+    workflow = Workflow()
+    workflow.add_task(task)
+    assert workflow.run() == ["ok"]
+    assert calls["n"] == 3
+    assert delays == [7, 7]
+
+
+def test_workflow_classic_retry_exhausted():
+    calls = {"n": 0}
+
+    def always_fail(task, context):
+        calls["n"] += 1
+        raise RuntimeError("nope")
+
+    task = _task(
+        "classic-exhausted",
+        CallableExecutor(always_fail),
+        retry_count=2,
+        retry_delay=0,
+        retry_until_completed=False,
+    )
+    workflow = Workflow()
+    workflow.add_task(task)
+    with pytest.raises(RuntimeError, match="nope"):
+        workflow.run()
+    assert calls["n"] == 3
+
+
+def test_workflow_round_times_resets_retry_budget():
+    calls = {"n": 0}
+
+    def fail_then_ok(task, context):
+        calls["n"] += 1
+        # Round 1: fail both attempts; round 2 first attempt succeeds.
+        if calls["n"] < 3:
+            raise RuntimeError(f"fail-{calls['n']}")
+        return "ok"
+
+    task = _task(
+        "budget-reset",
+        CallableExecutor(fail_then_ok),
+        round_times=2,
+        retry_count=1,
+        retry_delay=0,
+    )
+    workflow = Workflow()
+    workflow.add_task(task)
+    assert workflow.run() == ["ok"]
+    assert calls["n"] == 3
+
+
+def test_workflow_all_rounds_exhausted():
+    calls = {"n": 0}
+
+    def always_fail(task, context):
+        calls["n"] += 1
+        raise RuntimeError("nope")
+
+    task = _task(
+        "rounds-exhausted",
+        CallableExecutor(always_fail),
+        round_times=2,
+        retry_count=1,
+        retry_delay=0,
+    )
+    workflow = Workflow()
+    workflow.add_task(task)
+    with pytest.raises(RuntimeError, match="nope"):
+        workflow.run()
+    assert calls["n"] == 4  # 2 rounds × (1+1) attempts
+
+
+def test_workflow_round_timeout_hang_raises_within_budget():
+    """Hung execute must surface TimeoutError without waiting for the worker."""
+
+    def hang(task, context):
+        time.sleep(30)
+        return "never"
+
+    task = _task(
+        "hang",
+        CallableExecutor(hang),
+        round_timeout=1,
+        retry_count=0,
+        retry_delay=0,
+    )
+    workflow = Workflow()
+    workflow.add_task(task)
+    started = time.monotonic()
+    with pytest.raises(TimeoutError, match="round_timeout=1"):
+        workflow.run()
+    elapsed = time.monotonic() - started
+    assert elapsed < 5, f"soft timeout blocked too long: {elapsed:.2f}s"
+
+
+def test_workflow_executor_timeout_error_not_wrapped_as_round_timeout():
+    def boom_timeout(task, context):
+        raise TimeoutError("executor-own-timeout")
+
+    task = _task(
+        "exec-timeout",
+        CallableExecutor(boom_timeout),
+        round_timeout=5,
+        retry_count=0,
+    )
+    workflow = Workflow()
+    workflow.add_task(task)
+    with pytest.raises(TimeoutError, match="executor-own-timeout"):
+        workflow.run()
+
+
+def test_workflow_retry_until_max_is_per_round_not_global():
+    calls = {"n": 0}
+
+    def fail_until_round2(task, context):
+        calls["n"] += 1
+        # Round 1: 2 failures; round 2 first succeeds → proves budget resets.
+        if calls["n"] < 3:
+            raise RuntimeError(f"fail-{calls['n']}")
+        return "ok"
+
+    task = _task(
+        "until-per-round",
+        CallableExecutor(fail_until_round2),
+        round_times=2,
+        retry_until_completed=True,
+        retry_count=0,
+        retry_until_max=2,
+        retry_delay=0,
+    )
+    workflow = Workflow()
+    workflow.add_task(task)
+    assert workflow.run() == ["ok"]
+    assert calls["n"] == 3

--- a/tests/scheduler/test_workflow.py
+++ b/tests/scheduler/test_workflow.py
@@ -1,8 +1,24 @@
+import time
+
 import pytest
 
 from pypepper.scheduler.executor import CallableExecutor, Executor
 from pypepper.scheduler.task import Task
 from pypepper.scheduler.workflow import Workflow
+
+
+def _task(name: str, executor, **kwargs) -> Task:
+    return Task(
+        channel_id="c",
+        dag_id="d",
+        fingerprint=f"fp-{name}",
+        name=name,
+        category="c",
+        description="",
+        tags=[],
+        executor=executor,
+        **kwargs,
+    )
 
 
 def test_workflow_runs_executors_in_order():
@@ -16,25 +32,25 @@ def test_workflow_runs_executors_in_order():
         return CallableExecutor(_run)
 
     task_1 = Task(
-        channel_id='channel_1',
-        dag_id='dag_1',
-        fingerprint='fingerprint_1',
-        name='Test Task',
-        category='Test Category',
-        description='This is a test task',
+        channel_id="channel_1",
+        dag_id="dag_1",
+        fingerprint="fingerprint_1",
+        name="Test Task",
+        category="Test Category",
+        description="This is a test task",
         tags=[],
-        executor=make_exec('t1'),
+        executor=make_exec("t1"),
     )
 
     task_2 = Task(
-        channel_id='channel_2',
-        dag_id='dag_2',
-        fingerprint='fingerprint_2',
-        name='Another Test Task',
-        category='Another Test Category',
-        description='This is another test task',
+        channel_id="channel_2",
+        dag_id="dag_2",
+        fingerprint="fingerprint_2",
+        name="Another Test Task",
+        category="Another Test Category",
+        description="This is another test task",
         tags=[],
-        executor=make_exec('t2'),
+        executor=make_exec("t2"),
     )
 
     workflow = Workflow()
@@ -49,76 +65,154 @@ def test_workflow_runs_executors_in_order():
     assert tasks[1] == task_2
 
     results = workflow.run()
-    assert results == ['t1', 't2']
-    assert executed == ['t1', 't2']
+    assert results == ["t1", "t2"]
+    assert executed == ["t1", "t2"]
 
 
 def test_workflow_optional_task_failure_continues():
     def boom(task, context):
-        raise RuntimeError('boom')
+        raise RuntimeError("boom")
 
     def ok(task, context):
-        return 'ok'
+        return "ok"
 
-    failing = Task(
-        channel_id='c',
-        dag_id='d',
-        fingerprint='f',
-        name='fail',
-        category='c',
-        description='',
-        tags=[],
-        executor=CallableExecutor(boom),
-        optional=True,
-    )
-    succeeding = Task(
-        channel_id='c',
-        dag_id='d',
-        fingerprint='f2',
-        name='ok',
-        category='c',
-        description='',
-        tags=[],
-        executor=CallableExecutor(ok),
-    )
+    failing = _task("fail", CallableExecutor(boom), optional=True)
+    succeeding = _task("ok", CallableExecutor(ok))
 
     workflow = Workflow()
     workflow.add_tasks([failing, succeeding])
-    assert workflow.run() == [None, 'ok']
+    assert workflow.run() == [None, "ok"]
 
 
 def test_workflow_non_optional_failure_raises():
     def boom(task, context):
-        raise RuntimeError('boom')
+        raise RuntimeError("boom")
 
-    task = Task(
-        channel_id='c',
-        dag_id='d',
-        fingerprint='f',
-        name='fail',
-        category='c',
-        description='',
-        tags=[],
-        executor=CallableExecutor(boom),
-        optional=False,
-    )
+    task = _task("fail", CallableExecutor(boom), optional=False)
     workflow = Workflow()
     workflow.add_task(task)
-    with pytest.raises(RuntimeError, match='boom'):
+    with pytest.raises(RuntimeError, match="boom"):
         workflow.run()
 
 
 def test_noop_executor():
-    task = Task(
-        channel_id='c',
-        dag_id='d',
-        fingerprint='f',
-        name='noop',
-        category='c',
-        description='',
-        tags=[],
-        executor=Executor(),
-    )
+    task = _task("noop", Executor())
     workflow = Workflow()
     workflow.add_task(task)
     assert workflow.run() == [None]
+
+
+def test_workflow_round_times_succeeds_on_later_round():
+    calls = {"n": 0}
+
+    def flaky(task, context):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise RuntimeError(f"fail-{calls['n']}")
+        return "ok"
+
+    task = _task("rounds", CallableExecutor(flaky), round_times=3, retry_count=0)
+    workflow = Workflow()
+    workflow.add_task(task)
+    assert workflow.run() == ["ok"]
+    assert calls["n"] == 3
+
+
+def test_workflow_round_timeout_counts_as_failure_then_retry():
+    calls = {"n": 0}
+
+    def slow_then_fast(task, context):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            time.sleep(1.5)
+            return "late"
+        return "ok"
+
+    task = _task(
+        "timeout",
+        CallableExecutor(slow_then_fast),
+        round_timeout=1,
+        retry_count=1,
+        retry_delay=0,
+    )
+    workflow = Workflow()
+    workflow.add_task(task)
+    assert workflow.run() == ["ok"]
+    assert calls["n"] == 2
+
+
+def test_workflow_retry_until_completed_with_zero_count():
+    calls = {"n": 0}
+
+    def eventually(task, context):
+        calls["n"] += 1
+        if calls["n"] < 4:
+            raise RuntimeError("not yet")
+        return "done"
+
+    task = _task(
+        "until",
+        CallableExecutor(eventually),
+        retry_until_completed=True,
+        retry_count=0,
+        retry_until_max=10,
+        retry_delay=0,
+    )
+    workflow = Workflow()
+    workflow.add_task(task)
+    assert workflow.run() == ["done"]
+    assert calls["n"] == 4
+
+
+def test_workflow_retry_until_with_count_caps_attempts():
+    calls = {"n": 0}
+
+    def always_fail(task, context):
+        calls["n"] += 1
+        raise RuntimeError("nope")
+
+    task = _task(
+        "until-cap",
+        CallableExecutor(always_fail),
+        retry_until_completed=True,
+        retry_count=2,
+        retry_until_max=100,
+        retry_delay=0,
+    )
+    workflow = Workflow()
+    workflow.add_task(task)
+    with pytest.raises(RuntimeError, match="nope"):
+        workflow.run()
+    assert calls["n"] == 3
+
+
+def test_workflow_retry_until_max_exhausted():
+    calls = {"n": 0}
+
+    def always_fail(task, context):
+        calls["n"] += 1
+        raise RuntimeError("nope")
+
+    task = _task(
+        "until-max",
+        CallableExecutor(always_fail),
+        retry_until_completed=True,
+        retry_count=0,
+        retry_until_max=5,
+        retry_delay=0,
+    )
+    workflow = Workflow()
+    workflow.add_task(task)
+    with pytest.raises(RuntimeError, match="nope"):
+        workflow.run()
+    assert calls["n"] == 5
+
+
+def test_task_rejects_invalid_retry_until_max():
+    with pytest.raises(ValueError, match="retry_until_max"):
+        _task("bad", Executor(), retry_until_max=0)
+
+
+def test_task_rejects_invalid_round_times():
+    with pytest.raises(ValueError, match="round_times"):
+        _task("bad", Executor(), round_times=0)

--- a/tests/scheduler/test_workflow.py
+++ b/tests/scheduler/test_workflow.py
@@ -1,4 +1,8 @@
+import threading
 import time
+from concurrent.futures import Future
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+from unittest.mock import patch
 
 import pytest
 
@@ -319,9 +323,12 @@ def test_workflow_all_rounds_exhausted():
 
 def test_workflow_round_timeout_hang_raises_within_budget():
     """Hung execute must surface TimeoutError without waiting for the worker."""
+    release = threading.Event()
+    entered = threading.Event()
 
     def hang(task, context):
-        time.sleep(30)
+        entered.set()
+        release.wait(timeout=60)
         return "never"
 
     task = _task(
@@ -334,10 +341,48 @@ def test_workflow_round_timeout_hang_raises_within_budget():
     workflow = Workflow()
     workflow.add_task(task)
     started = time.monotonic()
-    with pytest.raises(TimeoutError, match="round_timeout=1"):
-        workflow.run()
-    elapsed = time.monotonic() - started
-    assert elapsed < 5, f"soft timeout blocked too long: {elapsed:.2f}s"
+    try:
+        with pytest.raises(TimeoutError, match="round_timeout=1"):
+            workflow.run()
+        elapsed = time.monotonic() - started
+        assert elapsed < 5, f"soft timeout blocked too long: {elapsed:.2f}s"
+        assert entered.wait(timeout=2), "worker never started"
+    finally:
+        release.set()
+
+
+def test_workflow_soft_timeout_returns_result_when_worker_finishes_in_race():
+    """If wait times out but the future completed successfully, return the result."""
+    shutdown_calls: list[dict] = []
+
+    class _RacePool:
+        def __init__(self, *args, **kwargs):
+            self._future = Future()
+            self._future.set_result("ok")
+
+        def submit(self, fn, *args, **kwargs):
+            return self._future
+
+        def shutdown(self, wait=True, cancel_futures=False):
+            shutdown_calls.append({"wait": wait, "cancel_futures": cancel_futures})
+
+    real_result = Future.result
+
+    def result_raise_timeout_once(self, timeout=None):
+        if timeout is not None:
+            raise FuturesTimeoutError()
+        return real_result(self, timeout=timeout)
+
+    with (
+        patch("pypepper.scheduler.workflow.ThreadPoolExecutor", _RacePool),
+        patch.object(Future, "result", result_raise_timeout_once),
+    ):
+        task = _task("race", CallableExecutor(lambda t, c: "unused"), round_timeout=1)
+        workflow = Workflow()
+        workflow.add_task(task)
+        assert workflow.run() == ["ok"]
+
+    assert shutdown_calls == [{"wait": False, "cancel_futures": False}]
 
 
 def test_workflow_executor_timeout_error_not_wrapped_as_round_timeout():

--- a/tests/scheduler/test_workflow.py
+++ b/tests/scheduler/test_workflow.py
@@ -227,6 +227,16 @@ def test_task_rejects_negative_round_timeout():
         _task("bad", Executor(), round_timeout=-1)
 
 
+def test_task_rejects_negative_retry_delay():
+    with pytest.raises(ValueError, match="retry_delay"):
+        _task("bad", Executor(), retry_delay=-1)
+
+
+def test_task_rejects_negative_retry_count():
+    with pytest.raises(ValueError, match="retry_count"):
+        _task("bad", Executor(), retry_count=-1)
+
+
 def test_workflow_classic_retry_count_and_delay(monkeypatch):
     calls = {"n": 0}
     delays: list[float] = []


### PR DESCRIPTION
## Summary
- Wire `round_times`, soft `round_timeout` (seconds), and `retry_until_completed` (A3) in `Workflow._run_task` so Task fields actually drive execution.
- Add Task-configurable `retry_until_max` (default 1000) as the hard cap when `until=True` and `retry_count==0`.
- Update scheduler guide + CHANGELOG; expand workflow tests for rounds/timeout/until/cap.

## Test plan
- [x] `make check`
- [x] `make docs`
- [x] `pytest tests/scheduler/test_workflow.py tests/scheduler/test_task.py`
- [x] `pytest tests/scheduler/ --ignore=tests/scheduler/test_job_store_db.py`
- [ ] CI green on this PR