### PR TITLE
fix(network/sse)!: require env to allow authentication off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Breaking
+- SSE: `sse.authentication.enabled: false` no longer accepts any non-empty API key by default. Requests are rejected (decorator: HTTP 503) unless `PYPEPPER_SSE_ALLOW_AUTH_OFF=1` (or `true`/`yes`/`on`) is set for local experiments.
+
 ### Added
 - `Task.retry_until_max` (default 1000): per-round attempt cap when `retry_until_completed=True` and `retry_count==0`.
 - `Task` rejects negative `retry_count` / `retry_delay`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,6 +31,7 @@ Include:
 
 ## Non-vulnerabilities
 
-Misconfiguration of optional features (for example leaving
-`sse.authentication.enabled: false` in production) is documented as an operator
-footgun, not a library vulnerability. See the [SSE guide](https://jovijovi.github.io/pypepper/guides/network-sse/).
+Leaving `sse.authentication.enabled: false` **without**
+`PYPEPPER_SSE_ALLOW_AUTH_OFF` is rejected by the library (503). Setting the escape
+env for local experiments is an operator choice and not a library vulnerability.
+See the [SSE guide](https://jovijovi.github.io/pypepper/guides/network-sse/).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,7 +84,8 @@ Connect:
 curl -N -H "X-API-Key: $PYPEPPER_SSE_API_KEY" http://localhost:55550/sse/echo
 ```
 
-Keep `sse.authentication.enabled: true` for anything beyond local experiments
+Keep `sse.authentication.enabled: true` for anything beyond local experiments.
+To temporarily allow auth-off locally, export `PYPEPPER_SSE_ALLOW_AUTH_OFF=1`
 (see [SSE security notes](guides/network-sse.md#security-notes)).
 
 ## Documentation site

--- a/docs/guides/network-sse.md
+++ b/docs/guides/network-sse.md
@@ -78,7 +78,7 @@ async def clock(request: Request):
 ### Security notes
 
 - **Production:** keep `sse.authentication.enabled: true` and inject `validKeys` (do not commit real keys).
-- **Auth off is not anonymous access.** When `authentication.enabled` is `false`, any **non-empty** API key is accepted. The library logs a **one-shot** warning (once per process) when this path is used.
+- **Auth off is blocked by default.** Setting `authentication.enabled: false` rejects requests with **503** unless you explicitly export `PYPEPPER_SSE_ALLOW_AUTH_OFF=1` (or `true` / `yes` / `on`). With that escape set, any **non-empty** API key is accepted and the library logs a **one-shot** warning (once per process).
 - **Rate limiting is not a security boundary when auth is off.** Limits are bucketed by the presented key string, so clients can rotate keys to bypass quotas. Treat rate limits as abuse soft-control only when authentication is enabled.
 
 See the full working app in [`example/sse/app.py`](https://github.com/jovijovi/pypepper/blob/main/example/sse/app.py).

--- a/docs/tutorials/first-service.md
+++ b/docs/tutorials/first-service.md
@@ -79,7 +79,8 @@ curl -N -H "X-API-Key: $PYPEPPER_SSE_API_KEY" http://localhost:55550/sse/echo
 ```
 
 You should see SSE event frames. Keep
-`sse.authentication.enabled: true` outside local experiments
+`sse.authentication.enabled: true` outside local experiments. Auth-off requires
+`PYPEPPER_SSE_ALLOW_AUTH_OFF=1`
 (see [SSE security notes](../guides/network-sse.md#security-notes)).
 
 ## Next

--- a/pypepper/network/http/sse/security.py
+++ b/pypepper/network/http/sse/security.py
@@ -1,5 +1,8 @@
 """SSE API key authentication helpers."""
 
+from __future__ import annotations
+
+import os
 from collections.abc import Callable
 from functools import wraps
 from hmac import compare_digest
@@ -12,29 +15,63 @@ from pypepper.common.cache import Cache
 from pypepper.common.config import config
 from pypepper.common.log import log
 
+_AUTH_OFF_ENV = "PYPEPPER_SSE_ALLOW_AUTH_OFF"
+_AUTH_OFF_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
 _auth_disabled_warned = False
-_auth_disabled_warn_lock = Lock()
+_auth_off_blocked_warned = False
+_auth_warn_lock = Lock()
+
+AUTH_OFF_BLOCKED_DETAIL = (
+    "SSE authentication cannot be disabled without "
+    f"{_AUTH_OFF_ENV}=1 (or true/yes/on); "
+    "set sse.authentication.enabled: true and inject validKeys, "
+    f"or export {_AUTH_OFF_ENV}=1 for local experiments only"
+)
+
+
+def _auth_off_allowed() -> bool:
+    """Return True when env explicitly allows authentication.enabled: false."""
+    raw = os.environ.get(_AUTH_OFF_ENV, "").strip().lower()
+    return raw in _AUTH_OFF_TRUTHY
 
 
 def _warn_auth_disabled_once() -> None:
     """Log once that auth-off accepts any non-empty key and is not a security boundary."""
     global _auth_disabled_warned
-    with _auth_disabled_warn_lock:
+    with _auth_warn_lock:
         if _auth_disabled_warned:
             return
         _auth_disabled_warned = True
     log.warn(
-        "sse.authentication.enabled is false: any non-empty API key is accepted; "
+        "sse.authentication.enabled is false and "
+        f"{_AUTH_OFF_ENV} is set: any non-empty API key is accepted; "
         "rate limiting buckets by presented key and is not a security boundary. "
         "Enable authentication and inject validKeys for production."
     )
 
 
+def _warn_auth_off_blocked_once() -> None:
+    """Log once that auth-off was requested without the escape env."""
+    global _auth_off_blocked_warned
+    with _auth_warn_lock:
+        if _auth_off_blocked_warned:
+            return
+        _auth_off_blocked_warned = True
+    log.warn(
+        "sse.authentication.enabled is false but "
+        f"{_AUTH_OFF_ENV} is not set: rejecting requests. "
+        f"Export {_AUTH_OFF_ENV}=1 to allow auth-off locally, "
+        "or enable authentication and inject validKeys."
+    )
+
+
 def reset_auth_disabled_warning() -> None:
-    """Reset the one-shot auth-off warning (tests)."""
-    global _auth_disabled_warned
-    with _auth_disabled_warn_lock:
+    """Reset one-shot auth-off warnings (tests)."""
+    global _auth_disabled_warned, _auth_off_blocked_warned
+    with _auth_warn_lock:
         _auth_disabled_warned = False
+        _auth_off_blocked_warned = False
 
 
 class SSESecurityManager:
@@ -57,6 +94,9 @@ class SSESecurityManager:
 
         sse_config = config.get_yml_config().sse
         if not sse_config.authentication.enabled:
+            if not _auth_off_allowed():
+                _warn_auth_off_blocked_once()
+                return False
             _warn_auth_disabled_once()
             return True
 
@@ -98,6 +138,9 @@ def require_sse_api_key(func: Callable) -> Callable:
 
     Query-string API keys are rejected to avoid log/Referer leakage.
 
+    When ``sse.authentication.enabled`` is false, requests are rejected with 503
+    unless ``PYPEPPER_SSE_ALLOW_AUTH_OFF`` is set (local experiments only).
+
     Usage:
         @app.get('/sse')
         @require_sse_api_key
@@ -107,6 +150,14 @@ def require_sse_api_key(func: Callable) -> Callable:
 
     @wraps(func)
     async def wrapper(request: Request, *args: Any, **kwargs: Any):
+        sse_config = config.get_yml_config().sse
+        if not sse_config.authentication.enabled and not _auth_off_allowed():
+            _warn_auth_off_blocked_once()
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=AUTH_OFF_BLOCKED_DETAIL,
+            )
+
         authorization = request.headers.get("Authorization", "")
         bearer = ""
         if authorization.lower().startswith("bearer "):
@@ -125,7 +176,6 @@ def require_sse_api_key(func: Callable) -> Callable:
         # Rate limit check
         client_id = api_key or ""
         if not SSESecurityManager.check_rate_limit(client_id):
-            sse_config = config.get_yml_config().sse
             max_requests = sse_config.rateLimit.maxRequestsPerMinute
             raise HTTPException(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,

--- a/tests/network/http/sse/test_sse_security.py
+++ b/tests/network/http/sse/test_sse_security.py
@@ -5,7 +5,11 @@ from fastapi import HTTPException
 
 from pypepper.common.cache import Cache
 from pypepper.common.config import config
-from pypepper.network.http.sse.security import SSESecurityManager, require_sse_api_key
+from pypepper.network.http.sse.security import (
+    AUTH_OFF_BLOCKED_DETAIL,
+    SSESecurityManager,
+    require_sse_api_key,
+)
 
 
 def _build_sse_config(
@@ -42,11 +46,12 @@ def _mock_request(
 
 
 @pytest.fixture(autouse=True)
-def _reset_rate_limit_cache():
+def _reset_rate_limit_cache(monkeypatch):
     from pypepper.network.http.sse import security as sse_security
 
     SSESecurityManager._rate_limit_cache = Cache(maxsize=1000, ttl=60)
     sse_security.reset_auth_disabled_warning()
+    monkeypatch.delenv('PYPEPPER_SSE_ALLOW_AUTH_OFF', raising=False)
 
 
 def test_validate_api_key_returns_false_for_empty_key(monkeypatch):
@@ -72,12 +77,33 @@ def test_auth_disabled_empty_key_does_not_warn(monkeypatch):
     assert warns == []
 
 
-def test_validate_api_key_allows_any_key_when_auth_disabled(monkeypatch):
+def test_validate_api_key_rejects_when_auth_disabled_without_escape(monkeypatch):
     from pypepper.common.log import log
     from pypepper.network.http.sse import security as sse_security
 
     warns: list[str] = []
     monkeypatch.setattr(log, 'warn', lambda msg, *a, **k: warns.append(str(msg)))
+    monkeypatch.setattr(
+        config,
+        'get_yml_config',
+        lambda: _build_sse_config(auth_enabled=False),
+    )
+    sse_security.reset_auth_disabled_warning()
+    assert SSESecurityManager.validate_api_key('any-key') is False
+    assert any('PYPEPPER_SSE_ALLOW_AUTH_OFF' in w for w in warns)
+    # Second call does not spam another warn.
+    warns.clear()
+    assert SSESecurityManager.validate_api_key('other-key') is False
+    assert warns == []
+
+
+def test_validate_api_key_allows_any_key_when_auth_disabled_with_escape(monkeypatch):
+    from pypepper.common.log import log
+    from pypepper.network.http.sse import security as sse_security
+
+    warns: list[str] = []
+    monkeypatch.setattr(log, 'warn', lambda msg, *a, **k: warns.append(str(msg)))
+    monkeypatch.setenv('PYPEPPER_SSE_ALLOW_AUTH_OFF', '1')
     monkeypatch.setattr(
         config,
         'get_yml_config',
@@ -90,6 +116,17 @@ def test_validate_api_key_allows_any_key_when_auth_disabled(monkeypatch):
     warns.clear()
     assert SSESecurityManager.validate_api_key('other-key') is True
     assert warns == []
+
+
+@pytest.mark.parametrize('escape_value', ['true', 'YES', 'On'])
+def test_auth_off_escape_env_truthy_values(monkeypatch, escape_value):
+    monkeypatch.setenv('PYPEPPER_SSE_ALLOW_AUTH_OFF', escape_value)
+    monkeypatch.setattr(
+        config,
+        'get_yml_config',
+        lambda: _build_sse_config(auth_enabled=False),
+    )
+    assert SSESecurityManager.validate_api_key('k') is True
 
 
 def test_validate_api_key_checks_allow_list_when_auth_enabled(monkeypatch):
@@ -191,6 +228,43 @@ async def test_require_sse_api_key_raises_401_for_invalid_or_missing_key(monkeyp
     assert exc_info.value.status_code == 401
     assert exc_info.value.detail == 'Invalid or missing API key'
     assert exc_info.value.headers == {'WWW-Authenticate': 'Bearer'}
+
+
+@pytest.mark.asyncio
+async def test_require_sse_api_key_raises_503_when_auth_off_without_escape(monkeypatch):
+    monkeypatch.setattr(
+        config,
+        'get_yml_config',
+        lambda: _build_sse_config(auth_enabled=False),
+    )
+
+    @require_sse_api_key
+    async def handler(request):
+        return {'ok': True}
+
+    with pytest.raises(HTTPException) as exc_info:
+        await handler(_mock_request(headers={'X-API-Key': 'any-key'}))
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == AUTH_OFF_BLOCKED_DETAIL
+
+
+@pytest.mark.asyncio
+async def test_require_sse_api_key_allows_auth_off_with_escape(monkeypatch):
+    monkeypatch.setenv('PYPEPPER_SSE_ALLOW_AUTH_OFF', '1')
+    monkeypatch.setattr(
+        config,
+        'get_yml_config',
+        lambda: _build_sse_config(auth_enabled=False),
+    )
+
+    @require_sse_api_key
+    async def handler(request):
+        return {'ok': True}
+
+    request = _mock_request(headers={'X-API-Key': 'any-key'})
+    assert await handler(request) == {'ok': True}
+    assert request.state.api_key == 'any-key'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Problem: `sse.authentication.enabled: false` accepted any non-empty API key (production footgun).
- Why it matters: YAML misconfig silently disabled auth; rate limits bucketed by presented key were not a security boundary.
- What changed: Auth-off is blocked by default (decorator → HTTP 503). Escape only via `PYPEPPER_SSE_ALLOW_AUTH_OFF=1|true|yes|on`, which restores the old any-non-empty-key behavior with a one-shot warn. Docs / SECURITY / CHANGELOG Breaking updated.
- What did NOT change: Rate-limit switch semantics; empty `validKeys` with auth on still rejects all; no version bump.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] common
- [ ] event
- [ ] fsm
- [ ] helper
- [x] network
- [ ] scheduler
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #45 (next score-growth item after Task wiring)

## User-visible / Behavior Changes

- **Breaking:** `authentication.enabled: false` without `PYPEPPER_SSE_ALLOW_AUTH_OFF` rejects requests (503 via `require_sse_api_key`; `validate_api_key` returns `False`).
- With the escape env set, previous auth-off behavior remains for local experiments.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`) — auth-off no longer accepts arbitrary keys unless escape env is set
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: Tightens default SSE auth; escape is explicit env for local-only use.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local `.venv`, Python 3.x
- Relevant config (redacted): `sse.authentication.enabled: false` with/without `PYPEPPER_SSE_ALLOW_AUTH_OFF`

### Steps

1. `enabled: false`, no escape env → request with any key
2. Set `PYPEPPER_SSE_ALLOW_AUTH_OFF=1` → same request
3. `enabled: true` + allow-list (unchanged path)

### Expected

1. 503 / `validate_api_key` False
2. Accepted + one-shot warn
3. Allow-list / 401 as before

### Actual

Matches expected (unit tests).

## Evidence

- [x] Failing test/log before + passing after — new/rewritten tests in `tests/network/http/sse/test_sse_security.py`
- [x] Trace/log snippets — one-shot blocked / auth-off warns covered

## Human Verification (required)

- Verified scenarios: `make check`; `pytest tests/network/http/sse/test_sse_security.py` (17 passed); `make docs --strict`
- Edge cases checked: escape truthy values (`true`/`YES`/`On`); empty key still False; decorator 503 vs escape allow
- What you did **not** verify: full example app e2e against a live uvicorn process with auth-off YAML

## Compatibility / Migration

- Backward compatible? (`No`) — small breaking for auth-off without escape
- Config/env changes? (`Yes`) — new optional `PYPEPPER_SSE_ALLOW_AUTH_OFF`
- Migration needed? (`Yes`)
- If yes, exact upgrade steps:
  1. Prefer `sse.authentication.enabled: true` + inject `validKeys`, **or**
  2. For local experiments only: `export PYPEPPER_SSE_ALLOW_AUTH_OFF=1`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: set `PYPEPPER_SSE_ALLOW_AUTH_OFF=1` or revert PR / set `enabled: true` with keys
- Files/config to restore: `pypepper/network/http/sse/security.py`
- Known bad symptoms reviewers should watch for: unexpected 503 on SSE endpoints after upgrade when YAML still has auth off

## Risks and Mitigations

- Risk: Deployments that relied on auth-off without knowing break with 503
  - Mitigation: Clear 503 detail + docs/CHANGELOG Breaking + escape env
- Risk: Escape env left set in production
  - Mitigation: Documented as local-only; still logs one-shot warn when used

## Test plan

- [ ] CI lint + Python matrix green
- [ ] Confirm 503 without escape / allow with escape from review notes