### PR TITLE
ci(codecov): pin project/patch status to auto with 1% threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Changed
 - `Workflow` now honors `round_times`, `round_timeout` (soft per-execute timeout in seconds; orphaned work may overlap retries), and `retry_until_completed` with `retry_count` / `retry_until_max`. Previously these fields were stored but unused.
+- CI: root `codecov.yml` pins Codecov project/patch status to `target: auto` with `threshold: 1%` (relative to PR base), aligned with pytest `branch = true` uploads.
 
 ### Fixed
 - Soft `round_timeout`: if the worker finishes successfully in the wait-timeout race window, return its result instead of re-raising `TimeoutError`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ make check           # ruff + mypy + mutable class-attr guard
 make test            # check + pytest with coverage (>= 90%)
 ```
 
-CI uses branch coverage; Codecov project status is relative to the PR base with a 1% threshold (`codecov.yml`).
+Local and CI use branch coverage; Codecov project/patch status is relative to the PR base with a 1% threshold (`codecov.yml`).
 
 DB-backed tests need services from `devenv/ci.yaml`:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,8 @@ make check           # ruff + mypy + mutable class-attr guard
 make test            # check + pytest with coverage (>= 90%)
 ```
 
+CI uses branch coverage; Codecov project status is relative to the PR base with a 1% threshold (`codecov.yml`).
+
 DB-backed tests need services from `devenv/ci.yaml`:
 
 ```shell

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,6 +28,8 @@ make check   # lint + mutable class-attr guard
 make test    # check + pytest with coverage (line coverage must be >= 90%)
 ```
 
+CI uploads branch coverage (`branch = true`); Codecov project/patch compare against the PR base and allow a 1% threshold.
+
 DB-backed helper tests expect services from `devenv/ci.yaml` on localhost:
 
 ```shell

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,10 +25,10 @@ uv pip install -r requirements.txt
 ```shell
 make lint    # ruff + mypy on pypepper/
 make check   # lint + mutable class-attr guard
-make test    # check + pytest with coverage (line coverage must be >= 90%)
+make test    # check + pytest with coverage (>= 90%; branch coverage enabled)
 ```
 
-CI uploads branch coverage (`branch = true`); Codecov project/patch compare against the PR base and allow a 1% threshold.
+Local and CI upload branch coverage (`branch = true`). Codecov project compares overall coverage vs the PR base; patch compares changed lines vs an auto target; both allow a 1% threshold.
 
 DB-backed helper tests expect services from `devenv/ci.yaml` on localhost:
 


### PR DESCRIPTION
## Summary
- Add root `codecov.yml` with project/patch `target: auto` and `threshold: 1%`, aligned with pytest `branch = true` uploads.
- Document the Codecov gate in CHANGELOG, CONTRIBUTING, and getting-started.

## Test plan
- [ ] CI lint/docs job green
- [ ] Python test matrix green
- [ ] `codecov/project` and `codecov/patch` pass (or behave as expected for this config-only change)