### PR TITLE
ci(publish): sample pretest on Python 3.10 and 3.14

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,15 +37,18 @@ jobs:
   pretest:
     needs: lint
     runs-on: ubuntu-latest
-    name: Pre-publish tests (Python 3.13)
+    strategy:
+      matrix:
+        python: ["3.10", "3.14"]
+    name: Pre-publish tests (Python ${{ matrix.python }})
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Use python 3.13
+      - name: Use python ${{ matrix.python }}
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python }}
 
       - name: Install
         run: python -m pip install -r requirements-dev.txt ; python -m pip install -r requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changed
 - `Workflow` now honors `round_times`, `round_timeout` (soft per-execute timeout in seconds; orphaned work may overlap retries), and `retry_until_completed` with `retry_count` / `retry_until_max`. Previously these fields were stored but unused.
 - CI: root `codecov.yml` pins Codecov project/patch status to `target: auto` with `threshold: 1%` (relative to PR base), aligned with pytest `branch = true` uploads.
+- CI: tag publish `pretest` samples Python 3.10 and 3.14 (lint/docs and build/upload remain on 3.13).
 
 ### Fixed
 - Soft `round_timeout`: if the worker finishes successfully in the wait-timeout race window, return its result instead of re-raising `TimeoutError`.

--- a/docs/guides/release.md
+++ b/docs/guides/release.md
@@ -36,7 +36,7 @@ git push origin vX.Y.Z
 
 Example: if `pyproject.toml` has `version = "0.6.2"`, the tag must be `v0.6.2`.
 
-4. Watch **Actions → Publish to PyPI**. The workflow runs lint + tests first; a failing pretest or a tag/`pyproject.toml` version mismatch blocks upload.
+4. Watch **Actions → Publish to PyPI**. The workflow runs lint/docs on Python 3.13, then pretest on **Python 3.10 and 3.14** (sample ends of the supported range); build/upload stays on 3.13. A failing pretest or a tag/`pyproject.toml` version mismatch blocks upload.
 5. Confirm the version on [https://pypi.org/project/pypepper/](https://pypi.org/project/pypepper/).
 
 ## Manual fallback


### PR DESCRIPTION
## Summary

- Problem: Tag publish `pretest` only ran on Python 3.13, so release gating did not sample the supported range ends.
- Why it matters: Catches 3.10/3.14 regressions before PyPI upload without paying for a full five-version matrix on every tag.
- What changed: `publish.yml` pretest matrix `["3.10", "3.14"]`; `release.md` + CHANGELOG note. Lint/docs and build/upload remain on 3.13; `publish` still `needs: pretest` (all matrix legs).
- What did NOT change: `test.yaml` full PR matrix, Trusted Publisher, tag↔version check, Codecov upload on publish path.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] common
- [ ] event
- [ ] fsm
- [ ] helper
- [ ] network
- [ ] scheduler
- [x] CI/CD / infra

## Linked Issue/PR

- Related: R9 score-growth backlog item 6

## User-visible / Behavior Changes

None for library users. Tag publish now runs two pretest jobs (3.10 + 3.14) instead of one on 3.13.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Linux / GitHub Actions ubuntu-latest
- Runtime/container: N/A (workflow YAML)

### Steps

1. Review `.github/workflows/publish.yml` pretest `strategy.matrix.python`.
2. Open PR and wait for Test CI (lint/docs + matrix).
3. After merge, next `v*` tag should show pretest 3.10 and 3.14 before publish.

### Expected

- PR Test CI green; YAML valid.
- Future tag: two pretest legs; publish waits for both.

### Actual

- (filled after CI)

## Evidence

- [x] Diff of publish.yml matrix + docs
- [ ] Tag-path dual pretest (only on next `v*`; not run by this PR)

## Human Verification (required)

- Verified scenarios: Local diff matches plan (3.10+3.14 only; lint/publish still 3.13).
- Edge cases checked: `needs: pretest` unchanged so all matrix legs must pass.
- What you did **not** verify: Actual tag publish workflow run (publish only triggers on `v*`).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR / restore single `python-version: "3.13"` pretest.
- Files/config to restore: `.github/workflows/publish.yml`
- Known bad symptoms reviewers should watch for: One pretest leg red blocking publish; longer tag wall time (~2× pretest).

## Risks and Mitigations

- Risk: Tag path no longer pytest on 3.13 (only lint/docs + build).
  - Mitigation: Full 3.13 coverage remains on PR/`main` via `test.yaml`.
- Risk: Dual devenv pretest increases tag CI time/cost.
  - Mitigation: Intentional sample of two ends only; not full matrix.