### PR TITLE
chore(release): bump to 0.6.3 and polish README

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -185,3 +185,6 @@ cython_debug/
 /devenv
 /tests
 /.data
+
+# CodeGraph
+/.codegraph

--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,6 @@ cython_debug/
 /.data
 /.tmp
 /test_run.sh
+
+# CodeGraph
+/.codegraph

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.6.3
+
 ### Breaking
 - SSE: `sse.authentication.enabled: false` no longer accepts any non-empty API key by default. Requests are rejected (decorator: HTTP 503) unless `PYPEPPER_SSE_ALLOW_AUTH_OFF=1` (or `true`/`yes`/`on`) is set for local experiments.
 

--- a/README.md
+++ b/README.md
@@ -22,24 +22,21 @@
 
 ---
 
-PyPepper packages the pieces you wire into services: **HTTP / SSE**, **FSM**, a **workflow scheduler**, signed **events**, thin **DB helpers**, and optional **OpenTelemetry** tracing — for Python `3.10`–`3.14`.
+PyPepper is a small toolkit—not a full framework—for wiring services: **HTTP / SSE**, **FSM**, a **workflow scheduler**, signed **events**, thin **DB helpers**, and optional **OpenTelemetry** tracing. Supports Python `3.10`–`3.14`.
 
-- Project: [https://github.com/jovijovi/pypepper](https://github.com/jovijovi/pypepper)
-- Docs: [https://jovijovi.github.io/pypepper/](https://jovijovi.github.io/pypepper/)
+- Repo: [github.com/jovijovi/pypepper](https://github.com/jovijovi/pypepper)
+- Docs: [jovijovi.github.io/pypepper](https://jovijovi.github.io/pypepper/)
+- Changelog: [`CHANGELOG.md`](CHANGELOG.md)
+
+```shell
+pip install pypepper
+```
 
 ## Documentation
 
 [Getting Started](https://jovijovi.github.io/pypepper/getting-started/) · [Tutorial](https://jovijovi.github.io/pypepper/tutorials/first-service/) · [Architecture](https://jovijovi.github.io/pypepper/architecture/) · [Guides](https://jovijovi.github.io/pypepper/guides/common/) · [API Reference](https://jovijovi.github.io/pypepper/reference/)
 
 Source under [`docs/`](docs/index.md). Local preview: `make docs-serve`.
-
-## Contributing
-
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for setup, Conventional Commits, and PR expectations.
-
-## Security
-
-See [`SECURITY.md`](SECURITY.md) for supported versions and how to report vulnerabilities privately.
 
 ## Domains
 
@@ -48,7 +45,7 @@ See [`SECURITY.md`](SECURITY.md) for supported versions and how to report vulner
 | **Common** | `pypepper.common` | Config, logging, context, cache, crypto, utilities |
 | **Event** | `pypepper.event` | Signed domain events with JSON marshal |
 | **FSM** | `pypepper.fsm` | Event-triggered state machine with rollback |
-| **Scheduler** | `pypepper.scheduler` | `Job → Channel → Worker → Workflow` |
+| **Scheduler** | `pypepper.scheduler` | `Job → Channel → Worker → Workflow` + pluggable job stores |
 | **Network** | `pypepper.network` | FastAPI HTTP server and SSE subsystem |
 | **Helper** | `pypepper.helper` | MySQL / PostgreSQL / MongoDB connectors |
 
@@ -56,20 +53,22 @@ See [`SECURITY.md`](SECURITY.md) for supported versions and how to report vulner
 
 | | |
 |:--|:--|
-| **Network** | FastAPI HTTP + SSE with API-key auth and rate limits → [guide](https://jovijovi.github.io/pypepper/guides/network-sse/) |
-| **FSM & events** | Rollback on handler failure; signed payloads → [guide](https://jovijovi.github.io/pypepper/guides/event-fsm/) |
-| **Scheduler** | Workflow job pipeline with retries → [guide](https://jovijovi.github.io/pypepper/guides/scheduler/) |
+| **Network** | FastAPI HTTP + SSE; header API-key auth and rate limits (auth-off needs `PYPEPPER_SSE_ALLOW_AUTH_OFF`) → [guide](https://jovijovi.github.io/pypepper/guides/network-sse/) |
+| **FSM & events** | Rollback on handler failure; signed JSON payloads → [guide](https://jovijovi.github.io/pypepper/guides/event-fsm/) |
+| **Scheduler** | Rounds, soft timeouts, and retries; durable job-store fail-fast → [guide](https://jovijovi.github.io/pypepper/guides/scheduler/) |
 | **Tracing** | Opt-in OpenTelemetry (console / local Jaeger) → [guide](https://jovijovi.github.io/pypepper/guides/tracing/) |
-| **Quality** | PEP 561 `py.typed` · ruff + mypy CI · coverage `≥ 90%` |
+| **Quality** | PEP 561 `py.typed` · ruff + mypy CI · line + branch coverage `≥ 90%` |
 | **Data** | Thin DB helpers → [guide](https://jovijovi.github.io/pypepper/guides/helper-db/) |
 
 ## Quick start
 
-Requires Python `3.10`–`3.14` and [uv](https://github.com/astral-sh/uv) `≥ 0.10.7` (recommended).
+Requires Python `3.10`–`3.14`. [uv](https://github.com/astral-sh/uv) `≥ 0.10.7` is recommended for local installs.
 
 ```shell
 make build-prepare
 ```
+
+SSE example (set a key; default config enables authentication):
 
 ```shell
 export PYPEPPER_SSE_API_KEY=your-local-key
@@ -82,17 +81,31 @@ HTTP example:
 python example/server/app.py --config ./conf/app.config.yaml
 ```
 
-Full walkthrough: [Getting Started](https://jovijovi.github.io/pypepper/getting-started/).
+Scheduler end-to-end example: `python example/scheduler/app.py`.
+
+Full walkthrough: [Getting Started](https://jovijovi.github.io/pypepper/getting-started/) · [First service tutorial](https://jovijovi.github.io/pypepper/tutorials/first-service/).
 
 <details>
 <summary><strong>Developer commands</strong></summary>
 
 ```shell
 make lint     # ruff + mypy
-make test     # check + pytest (coverage ≥ 90%)
+make check    # lint + mutable class-attr guard
+make test     # check + pytest (coverage ≥ 90%, branch on)
 make docs     # mkdocs build --strict
+make audit    # pip-audit on production requirements
 make docker   # local image
 make clean
 ```
 
 </details>
+
+## Contributing
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for setup, Conventional Commits, and PR expectations.
+Release tags: [`docs/guides/release.md`](docs/guides/release.md).
+
+## Security
+
+See [`SECURITY.md`](SECURITY.md) for supported versions and private reporting.
+Leaving SSE authentication off without `PYPEPPER_SSE_ALLOW_AUTH_OFF` is rejected by the library (HTTP 503).

--- a/docs/guides/release.md
+++ b/docs/guides/release.md
@@ -34,7 +34,7 @@ git tag vX.Y.Z
 git push origin vX.Y.Z
 ```
 
-Example: if `pyproject.toml` has `version = "0.6.2"`, the tag must be `v0.6.2`.
+Example: if `pyproject.toml` has `version = "0.6.3"`, the tag must be `v0.6.3`.
 
 4. Watch **Actions → Publish to PyPI**. The workflow runs lint/docs on Python 3.13, then pretest on **Python 3.10 and 3.14** (sample ends of the supported range); build/upload stays on 3.13. A failing pretest or a tag/`pyproject.toml` version mismatch blocks upload.
 5. Confirm the version on [https://pypi.org/project/pypepper/](https://pypi.org/project/pypepper/).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pypepper"
-version = "0.6.2"
+version = "0.6.3"
 authors = [
     { name = "jovijovi", email = "mageyul@hotmail.com" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1961,7 +1961,7 @@ wheels = [
 
 [[package]]
 name = "pypepper"
-version = "0.6.2"
+version = "0.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "arrow" },


### PR DESCRIPTION
## Summary

- Problem: Tree still at 0.6.2 while merged work (#45–#50) lived under Unreleased; README lagged current SSE/scheduler/quality defaults.
- Why it matters: Cuts a coherent 0.6.3 release surface and keeps the project front door accurate for consumers.
- What changed: `pyproject.toml` / `uv.lock` → 0.6.3; CHANGELOG Unreleased → `## 0.6.3`; release guide example tag; README polish (toolkit positioning, install, highlights, examples, security note).
- What did NOT change: Library runtime code; no tag/`v0.6.3` push in this PR (publish after merge).

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] common
- [ ] event
- [ ] fsm
- [ ] helper
- [ ] network
- [ ] scheduler
- [x] CI/CD / infra

## Linked Issue/PR

- Related: #45–#50 (shipped under 0.6.3 notes)

## User-visible / Behavior Changes

None beyond documentation and package version metadata. Runtime behavior already on `main` from prior PRs; this PR packages them as 0.6.3.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Linux
- Runtime: local uv / GitHub Actions

### Steps

1. Confirm `pyproject.toml` version is `0.6.3` and `uv.lock` matches.
2. Confirm CHANGELOG has `## 0.6.3` with prior Unreleased bullets.
3. Skim README for SSE auth-off / scheduler / coverage wording.

### Expected

- Version and docs aligned for tag `v0.6.3` after merge.

### Actual

- (CI after open)

## Evidence

- [x] Diff of version + README + CHANGELOG
- [ ] Tag publish (after merge: `git tag v0.6.3 && git push origin v0.6.3`)

## Human Verification (required)

- Verified scenarios: Local diff vs main; version strings consistent across pyproject/uv.lock/release.md.
- Edge cases checked: README keeps logo/badges; Contributing/Security moved to end without dropping links.
- What you did **not** verify: PyPI upload (needs post-merge tag).

## Compatibility / Migration

- Backward compatible? (`Yes` for this PR metadata; 0.6.3 notes include prior Breaking SSE auth-off from #46)
- Config/env changes? (`No` in this PR)
- Migration needed? (`No` for the bump itself; operators already on main need `PYPEPPER_SSE_ALLOW_AUTH_OFF` if auth-off)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR / restore version `0.6.2`.
- Files/config to restore: `pyproject.toml`, `uv.lock`, `CHANGELOG.md`, `README.md`, `docs/guides/release.md`
- Known bad symptoms reviewers should watch for: Tag mismatch if someone tags `v0.6.2` after merge.

## Risks and Mitigations

- Risk: Tag forgotten after merge leaves PyPI on 0.6.2.
  - Mitigation: Follow release guide; tag must be `v0.6.3`.