### PR TITLE
fix(packaging): ~= ranges, drop runtime pip, widen Python patch bound

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -144,6 +144,7 @@ celerybeat.pid
 
 # Environments
 .env
+/.pypirc
 .venv
 env/
 venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changed
+- Packaging: runtime dependencies in `pyproject.toml` use compatible-release pins (`~=x.y.z`); exact pins remain in `requirements.txt` / `uv.lock`. Dropped unused runtime `pip` (still in the `dev` dependency group). `requires-python` is now `>=3.10, <3.15` so CPython 3.14.x patches remain installable. `.pypirc` is excluded from Docker build context via `.dockerignore`.
+
 ## 0.6.3
 
 ### Breaking

--- a/docs/guides/release.md
+++ b/docs/guides/release.md
@@ -21,7 +21,7 @@ Do this once before the first tag-triggered release.
    - Workflow name: `publish.yml`
    - Environment name: `pypi`
 
-No long-lived API token is stored in the repository. A local `.pypirc` (gitignored) is only for manual uploads.
+No long-lived API token is stored in the repository. A local `.pypirc` (gitignored and listed in `.dockerignore`) is only for manual uploads. If that file is exposed or you suspect a leak, revoke the token on PyPI / TestPyPI, create a new project-scoped token, and update your local `.pypirc`.
 
 ## Release checklist
 
@@ -41,7 +41,7 @@ Example: if `pyproject.toml` has `version = "0.6.3"`, the tag must be `v0.6.3`.
 
 ## Manual fallback
 
-Local publish (uses your machine credentials / `.pypirc`):
+Local publish (uses your machine credentials / `.pypirc`; prefer Trusted Publisher for tagged releases):
 
 ```shell
 make publish-test   # TestPyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "PyPepper is a microservice toolkit written in Python."
 readme = "README.md"
-requires-python = ">=3.10, <=3.14"
+requires-python = ">=3.10, <3.15"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
@@ -14,22 +14,21 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "arrow==1.4.0",
-    "cachetools==7.1.4",
-    "cryptography==49.0.0",
-    "fastapi==0.139.2",
-    "uvicorn==0.51.0",
-    "loguru==0.7.3",
-    "mongoengine==0.29.3",
-    "python-box==7.4.1",
-    "pymysql==1.2.0",
-    "psycopg[binary]==3.3.4",
-    "pyyaml==6.0.3",
-    "sqlalchemy==2.0.51",
-    "pip==26.1.2",
-    "opentelemetry-api==1.44.0",
-    "opentelemetry-sdk==1.44.0",
-    "opentelemetry-exporter-otlp-proto-http==1.44.0",
+    "arrow~=1.4.0",
+    "cachetools~=7.1.4",
+    "cryptography~=49.0.0",
+    "fastapi~=0.139.2",
+    "uvicorn~=0.51.0",
+    "loguru~=0.7.3",
+    "mongoengine~=0.29.3",
+    "python-box~=7.4.1",
+    "pymysql~=1.2.0",
+    "psycopg[binary]~=3.3.4",
+    "pyyaml~=6.0.3",
+    "sqlalchemy~=2.0.51",
+    "opentelemetry-api~=1.44.0",
+    "opentelemetry-sdk~=1.44.0",
+    "opentelemetry-exporter-otlp-proto-http~=1.44.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.10, <=3.14"
+requires-python = ">=3.10, <3.15"
 
 [[package]]
 name = "annotated-doc"
@@ -1973,7 +1973,6 @@ dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
-    { name = "pip" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pymysql" },
     { name = "python-box" },
@@ -2003,22 +2002,21 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "arrow", specifier = "==1.4.0" },
-    { name = "cachetools", specifier = "==7.1.4" },
-    { name = "cryptography", specifier = "==49.0.0" },
-    { name = "fastapi", specifier = "==0.139.2" },
-    { name = "loguru", specifier = "==0.7.3" },
-    { name = "mongoengine", specifier = "==0.29.3" },
-    { name = "opentelemetry-api", specifier = "==1.44.0" },
-    { name = "opentelemetry-exporter-otlp-proto-http", specifier = "==1.44.0" },
-    { name = "opentelemetry-sdk", specifier = "==1.44.0" },
-    { name = "pip", specifier = "==26.1.2" },
-    { name = "psycopg", extras = ["binary"], specifier = "==3.3.4" },
-    { name = "pymysql", specifier = "==1.2.0" },
-    { name = "python-box", specifier = "==7.4.1" },
-    { name = "pyyaml", specifier = "==6.0.3" },
-    { name = "sqlalchemy", specifier = "==2.0.51" },
-    { name = "uvicorn", specifier = "==0.51.0" },
+    { name = "arrow", specifier = "~=1.4.0" },
+    { name = "cachetools", specifier = "~=7.1.4" },
+    { name = "cryptography", specifier = "~=49.0.0" },
+    { name = "fastapi", specifier = "~=0.139.2" },
+    { name = "loguru", specifier = "~=0.7.3" },
+    { name = "mongoengine", specifier = "~=0.29.3" },
+    { name = "opentelemetry-api", specifier = "~=1.44.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = "~=1.44.0" },
+    { name = "opentelemetry-sdk", specifier = "~=1.44.0" },
+    { name = "psycopg", extras = ["binary"], specifier = "~=3.3.4" },
+    { name = "pymysql", specifier = "~=1.2.0" },
+    { name = "python-box", specifier = "~=7.4.1" },
+    { name = "pyyaml", specifier = "~=6.0.3" },
+    { name = "sqlalchemy", specifier = "~=2.0.51" },
+    { name = "uvicorn", specifier = "~=0.51.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

- Problem: Published metadata exact-pinned all runtime deps (and included unused `pip`), `requires-python = "<=3.14"` blocked CPython 3.14.1+, and `.pypirc` was not excluded from Docker build context.
- Why it matters: Downstream `pip install pypepper` co-installability, installability on 3.14.x patches, and local token hygiene.
- What changed: Runtime deps use `~=x.y.z`; removed runtime `pip` (kept in `dev`); `requires-python` → `>=3.10, <3.15`; `.pypirc` in `.dockerignore`; release guide notes token rotation.
- What did NOT change: `requirements.txt` / CI still use exact `==` pins; no version bump / PyPI release; token rotation remains a manual operator step.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] common
- [ ] event
- [ ] fsm
- [ ] helper
- [ ] network
- [ ] scheduler
- [x] CI/CD / infra

## Linked Issue/PR

- Related: R11 packaging boundary findings

## User-visible / Behavior Changes

- Installers of the *next* published release will resolve runtime deps under `~=` ranges (same baselines as today) and will no longer pull `pip` as a library dependency.
- `requires-python` allows `3.14.x` patches; still excludes `3.15+`.
- No runtime code / API behavior change in this PR itself (metadata + docs + ignore only until the next release).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`) — `.pypirc` added to `.dockerignore` so Docker build context does not upload local tokens; docs remind operators to revoke/rotate if exposed. Tokens are not committed; rotation is manual.
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: Local `.pypirc` tokens should be rotated on PyPI/TestPyPI if previously exposed via build context or workspace tooling.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local `.venv`
- Relevant config (redacted): n/a

### Steps

1. Inspect `pyproject.toml` `[project] dependencies` and `requires-python`.
2. `uv lock` / SpecifierSet check for `3.14.1` vs `3.15.0`.
3. `make check`.

### Expected

- No runtime `pip`; all runtime deps `~=`; `requires-python = ">=3.10, <3.15"`; `3.14.1` allowed, `3.15.0` denied; check green.

### Actual

- Matches expected.

## Evidence

- [x] SpecifierSet: `3.14.1` ∈ range, `3.15.0` ∉
- [x] `make check` (ruff + mypy + mutable-attr) passed after change
- [x] `uv.lock` `requires-python = ">=3.10, <3.15"`

## Human Verification (required)

- Verified scenarios: metadata shape, SpecifierSet, `make check`, `requirements.txt` still exact/`pip`-free
- Edge cases checked: `pip` retained in `dependency-groups.dev` and `requirements-dev.txt`
- What you did **not** verify: actual PyPI/TestPyPI token revoke+recreate (operator action); full `make test` matrix in CI (pending on this PR)

## Compatibility / Migration

- Backward compatible? (`Yes` for installed code; published metadata changes take effect on next release)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: n/a

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit / close PR
- Files/config to restore: `pyproject.toml`, `uv.lock`, `.dockerignore`, `CHANGELOG.md`, `docs/guides/release.md`
- Known bad symptoms reviewers should watch for: Dependabot/lock resolve surprises if a patch within `~=` is yanked (repo CI still pins via `requirements.txt`)

## Risks and Mitigations

- Risk: Downstream installs may pull newer patch versions within the same minor than this repo's `requirements.txt`.
  - Mitigation: Ranges are intentionally tight (`~=x.y.z`); CI continues to use exact pins.
- Risk: Local PyPI tokens still need manual rotation.
  - Mitigation: Documented in release guide; not automated in this PR.