### PR TITLE
chore(release): bump version to 0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.6.4
+
 ### Breaking
 - `Channel.stop` is **read-only**; use `Channel.request_stop()` to stop (assignment `Channel.stop = True` no longer works).
 - `ChannelStoppedError` is a **sibling** of `ChannelFullError` (not a subclass). Code that only catches `ChannelFullError` no longer treats channel-stopped as full/backpressure.

--- a/docs/guides/release.md
+++ b/docs/guides/release.md
@@ -34,7 +34,7 @@ git tag vX.Y.Z
 git push origin vX.Y.Z
 ```
 
-Example: if `pyproject.toml` has `version = "0.6.3"`, the tag must be `v0.6.3`.
+Example: if `pyproject.toml` has `version = "0.6.4"`, the tag must be `v0.6.4`.
 
 4. Watch **Actions → Publish to PyPI**. The workflow runs lint/docs on Python 3.13, then pretest on **Python 3.10 and 3.14** (sample ends of the supported range); build/upload stays on 3.13. A failing pretest or a tag/`pyproject.toml` version mismatch blocks upload.
 5. Confirm the version on [https://pypi.org/project/pypepper/](https://pypi.org/project/pypepper/).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pypepper"
-version = "0.6.3"
+version = "0.6.4"
 authors = [
     { name = "jovijovi", email = "mageyul@hotmail.com" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1961,7 +1961,7 @@ wheels = [
 
 [[package]]
 name = "pypepper"
-version = "0.6.3"
+version = "0.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "arrow" },


### PR DESCRIPTION
## Summary
- Bump package version from 0.6.3 to 0.6.4 in `pyproject.toml` / `uv.lock`
- Fold Unreleased notes into `CHANGELOG.md` section `## 0.6.4`
- Align release guide example tag to `v0.6.4`

## Test plan
- [ ] Confirm `pyproject.toml` version is `0.6.4` and matches `uv.lock`
- [ ] Confirm `CHANGELOG.md` has empty Unreleased and a `0.6.4` section
- [ ] After merge: tag `v0.6.4` and verify publish workflow