### PR TITLE
docs(release): add 0.6.5 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 0.6.5
+
+### Changed
+- Updated production dependencies: `cachetools` 7.1.4 → 7.1.7, `cryptography` 49.0.0 → 50.0.0, `fastapi` 0.139.2 → 0.141.1, `uvicorn` 0.51.0 → 0.52.1, and `sqlalchemy` 2.0.51 → 2.0.52.
+- Refreshed development dependencies, including `coverage` 7.15.3, `mkdocs-material` 9.7.6, `mkdocstrings` 1.0.6, `pip` 26.2, `ruff` 0.16.1, and `twine` 7.0.0.
+- Updated GitHub Actions workflows from `actions/setup-python@v6` to `@v7`.
+- Updated the Dockerfile frontend from 1.25.0 to 1.26.0 and the uv image from 0.11.30 to 0.12.3.
+
 ## 0.6.4
 
 ### Breaking


### PR DESCRIPTION
## Summary

- Problem: the 0.6.5 package, dependency, CI, and container updates were not documented in the changelog.
- Why it matters: release notes must reflect the actual changes since v0.6.4 before tagging and publishing.
- What changed: added a dedicated 0.6.5 Changed section covering production/dev dependencies, setup-python v7, Dockerfile frontend 1.26.0, and uv 0.12.3.
- What did NOT change (scope boundary): no code, dependency, workflow, or container configuration was modified.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] common
- [ ] event
- [ ] fsm
- [ ] helper
- [ ] network
- [ ] scheduler
- [x] CI/CD / infra

## Linked Issue/PR

- Related #64

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Documentation-only change
- Relevant config (redacted): None

### Steps

1. Compare CHANGELOG.md against git changes from v0.6.4 to main.
2. Confirm the new 0.6.5 section lists the production, development, CI, and Docker updates.
3. Run git diff --check.

### Expected

- The 0.6.5 release changes are documented without modifying the existing 0.6.4 section.

### Actual

- The release changes are documented and git diff --check passes.

## Evidence

- [x] Trace/log snippets: git diff --check completed successfully.

## Human Verification (required)

- Verified scenarios: compared CHANGELOG entries with v0.6.4..main commits and dependency/config diffs.
- Edge cases checked: retained an empty Unreleased section and preserved the published 0.6.4 section unchanged.
- What you did **not** verify: no build or runtime tests were run because this PR changes Markdown only.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the single documentation commit.
- Files/config to restore: CHANGELOG.md.
- Known bad symptoms reviewers should watch for: dependency versions inconsistent with v0.6.4..main.

## Risks and Mitigations

- Risk: release notes could omit or misstate a dependency/tooling update.
  - Mitigation: entries were derived from the complete v0.6.4..main diff.